### PR TITLE
OpenGL maps now use a virtual use function (API BREAKING)

### DIFF
--- a/source/draw/gpu/GpuMap.ooc
+++ b/source/draw/gpu/GpuMap.ooc
@@ -22,5 +22,5 @@ GpuMapType: enum {
 }
 
 GpuMap: abstract class {
-	use: abstract func
+	use: virtual func
 }

--- a/source/draw/gpu/opengl/Map/OpenGLES3MapPack.ooc
+++ b/source/draw/gpu/opengl/Map/OpenGLES3MapPack.ooc
@@ -3,12 +3,11 @@ use ooc-draw-gpu
 import OpenGLES3Map
 OpenGLES3MapPack: abstract class extends OpenGLES3MapDefault {
 	imageWidth: Int { get set }
-	init: func (fragmentSource: String, context: GpuContext) {
-		super(fragmentSource, context, false,
-			func {
-				this program setUniform("texture0", 0)
-				this program setUniform("imageWidth", this imageWidth)
-			})
+	init: func (fragmentSource: String, context: GpuContext) { super(fragmentSource, context, false) }
+	use: override func {
+		super()
+		this program setUniform("texture0", 0)
+		this program setUniform("imageWidth", this imageWidth)
 	}
 }
 OpenGLES3MapPackMonochrome: class extends OpenGLES3MapPack {
@@ -50,12 +49,12 @@ OpenGLES3MapPackUv: class extends OpenGLES3MapPack {
 OpenGLES3MapUnpackRgbaToMonochrome: class extends OpenGLES3MapDefault {
 	sourceSize: IntSize2D { get set }
 	targetSize: IntSize2D { get set }
-	init: func (context: GpuContext) {
-		super(This fragmentSource, context, false, func {
-			this program setUniform("texture0", 0)
-			this program setUniform("sourceSize", this sourceSize)
-			this program setUniform("targetSize", this targetSize)
-		})
+	init: func (context: GpuContext) { super(This fragmentSource, context, false) }
+	use: override func {
+		super()
+		this program setUniform("texture0", 0)
+		this program setUniform("sourceSize", this sourceSize)
+		this program setUniform("targetSize", this targetSize)
 	}
 	fragmentSource: static String ="
 		#version 300 es\n
@@ -82,14 +81,14 @@ OpenGLES3MapUnpackRgbaToMonochrome: class extends OpenGLES3MapDefault {
 OpenGLES3MapUnpackRgbaToUv: class extends OpenGLES3MapDefault {
 	sourceSize: IntSize2D { get set }
 	targetSize: IntSize2D { get set }
-	init: func (context: GpuContext) {
-		super(This fragmentSource, context, false, func {
-			this program setUniform("texture0", 0)
-			this program setUniform("sourceSize", this sourceSize)
-			this program setUniform("targetWidth", this targetSize width)
-			startY := (sourceSize height - targetSize height) as Float / sourceSize height
-			this program setUniform("startY", startY)
-		})
+	init: func (context: GpuContext) { super(This fragmentSource, context, false) }
+	use: override func {
+		super()
+		this program setUniform("texture0", 0)
+		this program setUniform("sourceSize", this sourceSize)
+		this program setUniform("targetWidth", this targetSize width)
+		startY := (sourceSize height - targetSize height) as Float / sourceSize height
+		this program setUniform("startY", startY)
 	}
 	fragmentSource: static String ="
 		#version 300 es\n

--- a/source/draw/gpu/opengl/OverlayDrawer.ooc
+++ b/source/draw/gpu/opengl/OverlayDrawer.ooc
@@ -22,7 +22,11 @@ import structs/LinkedList
 import OpenGLES3/Lines
 OpenGLES3MapLines: class extends OpenGLES3MapDefault {
 	color: FloatPoint3D { get set }
-	init: func (context: GpuContext) { super(This fragmentSource, context, true, func { this program setUniform("color", this color) }) }
+	init: func (context: GpuContext) { super(This fragmentSource, context, true) }
+	use: override func {
+		super()
+		this program setUniform("color", this color)
+	}
 	fragmentSource: static String ="
 		#version 300 es\n
 		precision highp float;\n
@@ -36,15 +40,14 @@ OpenGLES3MapPoints: class extends OpenGLES3Map {
 	color: FloatPoint3D { get set }
 	pointSize: Float { get set }
 	transform: FloatTransform2D { get set }
-	init: func (context: GpuContext) {
-		super(This vertexSource, This fragmentSource, context,
-			func {
-				this program setUniform("color", this color)
-				this program setUniform("pointSize", this pointSize)
-				reference: Float[16]
-				this transform to3DTransformArray(reference[0]&)
-				this program setUniform("transform", reference[0]&)
-			})
+	init: func (context: GpuContext) { super(This vertexSource, This fragmentSource, context) }
+	use: override func {
+		super()
+		this program setUniform("color", this color)
+		this program setUniform("pointSize", this pointSize)
+		reference: Float[16]
+		this transform to3DTransformArray(reference[0]&)
+		this program setUniform("transform", reference[0]&)
 	}
 	vertexSource: static String ="
 		#version 300 es\n


### PR DESCRIPTION
OpenGL maps now use a virtual use function instead of passing closure to base class. This breaks the Kean API when creating shader classes outside of Kean.