### PR TITLE
Fixed VectorList copy and added accumulate to FloatVectorList

### DIFF
--- a/source/collections/VectorList.ooc
+++ b/source/collections/VectorList.ooc
@@ -96,7 +96,7 @@ VectorList: class <T> {
 		}
 	}
 	copy: func -> This<T> {
-		result := This new()
+		result := This new(this _count)
 		memcpy(result pointer, this pointer, this _count * T size)
 		result _count = this _count
 		result

--- a/source/math/FloatVectorList.ooc
+++ b/source/math/FloatVectorList.ooc
@@ -79,6 +79,15 @@ FloatVectorList: class extends VectorList<Float> {
 			}
 		}
 	}
+	_accumulate: func -> This {
+		result := This new(this _count)
+		sum := 0
+		for (i in 0..this _count) {
+			sum += this[i]
+			result add(sum)
+		}
+		result
+	}
 	copy: func -> This {
 		result := This new(this _count)
 		for (i in 0..this _count)


### PR DESCRIPTION
VectorList copy could not handle lists with more than 32 elements.
Also added a method to accumulate FloatVectorList. 