### PR TITLE
Avoided build warning in SynchronizedQueue wait()

### DIFF
--- a/source/collections/SynchronizedQueue.ooc
+++ b/source/collections/SynchronizedQueue.ooc
@@ -66,7 +66,7 @@ BlockedQueue: class <T> extends SynchronizedQueue<T> {
 		this _mutex lock()
 		while (this empty)
 			this _populated wait(this _mutex)
-		success := this _backend dequeue(result&)
+		this _backend dequeue(result&) as Void // Ignore the return value to avoid build warning
 		this _mutex unlock()
 		result
 	}


### PR DESCRIPTION
Since `success` is not used in this function, the current code generates the build warning 
```
[CC] SynchronizedQueue
/home/dhesselbom/versioned/ooc/ooc-kean/source/collections/SynchronizedQueue.ooc: In function ‘SynchronizedQueue__BlockedQueue_wait’:
/home/dhesselbom/versioned/ooc/ooc-kean/source/collections/SynchronizedQueue.ooc:69:22: warning: unused variable ‘success’ [-Wunused-variable]
   success := this _backend dequeue(result&)
                      ^
```
Casting the result of the `dequeue` call to `Void` (as in this pull request) makes this warning go away, and should not affect the behavior in any way. This is how some people solve this problem in C++, apparently.

I'm not sure if this is a good idea, though. Can `dequeue` ever return `false` there on line 69? And if so, what should we do? Raise an exception? Carry on as if everything were fine?

@simonmika, @emilwestergren, your input is hereby requested.