### PR TITLE
Changed constructor when creating GpuImage from GraphicBuffers.

### DIFF
--- a/source/draw/gpu/android/GraphicBufferYuv420Semiplanar.ooc
+++ b/source/draw/gpu/android/GraphicBufferYuv420Semiplanar.ooc
@@ -7,26 +7,29 @@ import GraphicBuffer, AndroidContext
 GraphicBufferYuv420Semiplanar: class extends RasterYuv420Semiplanar {
 	_buffer: GraphicBuffer
 	buffer ::= this _buffer
-	_horizontalStride: Int
-	_verticalStride: Int
-	init: func ~fromBuffer (=_buffer, size: IntSize2D, align: Int, verticalAlign: Int) {
-		this _horizontalStride = Int align(size width, align)
-		this _verticalStride = Int align(size height, verticalAlign)
+	_stride: Int
+	_uvOffset: Int
+	uvOffset ::= this _uvOffset
+	uvPadding ::= (this _uvOffset - this _stride * this _size height)
+	init: func ~fromBuffer (=_buffer, size: IntSize2D, =_stride, =_uvOffset) {
 		ptr := _buffer lock()
 		_buffer unlock()
-		byteBuffer := ByteBuffer new(ptr, _buffer length, func (buffer: ByteBuffer) {} )
-		super(byteBuffer, size, align, verticalAlign)
+		length := 3 * this _stride * size width / 2
+		byteBuffer := ByteBuffer new(ptr, length, func (buffer: ByteBuffer) {} )
+		super(byteBuffer, size, 1, 1)
 	}
-	init: func (backend: Pointer, nativeBuffer: Pointer, handle: Pointer, size: IntSize2D, format: GraphicBufferFormat, pixelStride: Int, horizontalAlign: Int, verticalAlign: Int) {
-		this init(GraphicBuffer new(backend, nativeBuffer, handle, size, pixelStride, format), size, horizontalAlign, verticalAlign)
+	init: func (backend: Pointer, nativeBuffer: Pointer, handle: Pointer, size: IntSize2D, format: GraphicBufferFormat, stride: Int, uvOffset: Int) {
+		this init(GraphicBuffer new(backend, nativeBuffer, handle, size, stride, format), size, stride, uvOffset)
 	}
 	toRgba: func (context: AndroidContextManager) -> GpuBgra {
-		height := this _verticalStride + this buffer size height / 2
-		width := this buffer size width / 4
-		rgbaBuffer := GraphicBuffer new(this buffer handle, IntSize2D new(width, height), this _horizontalStride / 4, GraphicBufferFormat Rgba8888, GraphicBufferUsage Texture | GraphicBufferUsage Rendertarget)
+		padding := this _uvOffset - this _stride * this _size height
+		extraRows := Int align(padding, this _size width) / this _size width
+		height := this _size height + this _size height / 2 + extraRows
+		width := this _stride / 4
+		rgbaBuffer := GraphicBuffer new(this buffer handle, IntSize2D new(width, height), width, GraphicBufferFormat Rgba8888, GraphicBufferUsage Texture | GraphicBufferUsage Rendertarget)
 		context createBgra(rgbaBuffer)
 	}
-	new: unmangled(kean_draw_gpu_android_graphicBufferYuv420Semiplanar_new) static func ~API (backend: Pointer, nativeBuffer: Pointer, handle: Pointer, size: IntSize2D, pixelStride: Int, format: GraphicBufferFormat, verticalAlign: Int, horizontalAlign: Int) -> This {
-		This new(backend, nativeBuffer, handle, size, format, pixelStride, verticalAlign, horizontalAlign)
+	new: unmangled(kean_draw_gpu_android_graphicBufferYuv420Semiplanar_new) static func ~API (backend: Pointer, nativeBuffer: Pointer, handle: Pointer, size: IntSize2D, stride: Int, format: GraphicBufferFormat, uvOffset: Int) -> This {
+		This new(backend, nativeBuffer, handle, size, format, stride, uvOffset)
 	}
 }


### PR DESCRIPTION
It now takes an offset in bytes for where in the buffer the UV data begins instead of calculating it with align values. BREAKS API