### PR TITLE
Failed tests are now printed by name

### DIFF
--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -30,6 +30,7 @@ Fixture: abstract class {
 		this add(test)
 	}
 	run: func {
+		failures := ArrayList<TestFailedException> new()
 		result := true
 		(this name + " ") print()
 		this tests each(|test|
@@ -38,11 +39,17 @@ Fixture: abstract class {
 				test run()
 			} catch (e: TestFailedException) {
 				e test = test
+				e message = test name
 				result = r = false
+				failures add(e)
 			}
 			(r ? "." : "f") print()
 		)
 		(result ? " done" : " failed") println()
+		if (!result)
+			for (f in failures)
+				"  -> '%s'" printfln(f message)
+		failures free()
 		exit(result ? 0 : 1)
 	}
 	is ::= static IsConstraints new()
@@ -70,7 +77,9 @@ TestFailedException: class extends Exception {
 	test: Test
 	value: Object
 	constraint: Constraint
-	init: func (=value, =constraint)
+	init: func (=value, =constraint, message := "") {
+		this message = message
+	}
 }
 Test: class {
 	name: String

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 export OOC_LIBS=$(dirname `pwd`)
 ARGS=""
+FAILED=false
 if [ -e rock_arguments.txt ]
 	then
 		ARGS=$(cat rock_arguments.txt)
@@ -43,9 +44,14 @@ do
 		if [[ !( $? == 0 ) ]]
 		then
 			echo "Failed test: $TEST"
-			exit 1
+			FAILED=true
 		fi
 		rm -f $NAME
 	fi
 done
-exit 0
+if [ $FAILED ]
+then
+	exit 1
+else
+	exit 0
+fi

--- a/test.sh
+++ b/test.sh
@@ -49,7 +49,7 @@ do
 		rm -f $NAME
 	fi
 done
-if [ $FAILED ]
+if [ "$FAILED" = true ]
 then
 	exit 1
 else


### PR DESCRIPTION
* fixed so that the testing script continues to run tests even if one or more failed
* fixed so any failed tests are also printed by name

Sample output:
```
...
IntBox2D ....... done
FloatTransform3D ff................ failed
  -> 'equality'
  -> 'determinant'
Failed test: ./test/math/FloatTransform3DTest.ooc
FloatBox2D ......... done
...
```
