### PR TITLE
bug in "VectorList sort"

### DIFF
--- a/source/collections/VectorList.ooc
+++ b/source/collections/VectorList.ooc
@@ -87,7 +87,11 @@ VectorList: class <T> {
 		while (!inOrder) {
 			inOrder = true
 			for (i in 0 .. count - 1) {
-				if (greaterThan(this[i], this[i + 1])) {
+				a := this[i]
+				b := this[i + 1]
+				"values in VectorList: %i %i" format(a as Int, b as Int) println()
+				"addresses in VectorList: %i %i" format(a& as Int, b& as Int) println()
+				if (greaterThan(a,b)) {
 					inOrder = false
 					tmp := this[i]
 					this[i] = this[i + 1]

--- a/source/collections/VectorList.ooc
+++ b/source/collections/VectorList.ooc
@@ -89,8 +89,8 @@ VectorList: class <T> {
 			for (i in 0 .. count - 1) {
 				a := this[i]
 				b := this[i + 1]
-				"values in VectorList: %i %i" format(a as Int, b as Int) println()
-				"addresses in VectorList: %i %i" format(a& as Int, b& as Int) println()
+				//"values in VectorList: %i %i" format(a as Int, b as Int) println()
+				//"addresses in VectorList: %i %i" format(a& as Int, b& as Int) println()
 				if (greaterThan(a,b)) {
 					inOrder = false
 					tmp := this[i]

--- a/test/collections/VectorListTest.ooc
+++ b/test/collections/VectorListTest.ooc
@@ -28,7 +28,7 @@ VectorTest: class extends Fixture {
 
 	sortFunc: static func (a,b: Int) -> Bool {
 		result := a > b
-		"arguments to sortFunc %i, %i : %i" format(a,b,result) println()
+//		"arguments to sortFunc %i, %i : %i" format(a,b,result) println()
 		result
 	}
 	sortFuncClass: static func (a,b: TestClass) -> Bool {
@@ -151,12 +151,26 @@ VectorTest: class extends Fixture {
 			list free()
 			indices free()
 		})
-		this add("VectorList apply and sort", func {
+		this add("VectorList sort vector with integers", func {
+			list := VectorList<Int> new()
+			list add(1)
+			list add(3)
+			list add(2)
+			list sort(sortFunc)
+			expect(list[0] == 1)
+			expect(list[1] == 2)
+			expect(list[2] == 3)
+			list free()
+		})
+		this add("VectorList sort vector with class objects", func {
 			list := VectorList<TestClass> new()
 			list add(TestClass new(1))
 			list add(TestClass new(3))
 			list add(TestClass new(2))
 			list sort(sortFuncClass)
+			expect(list[0] value == 1)
+			expect(list[1] value == 2)
+			expect(list[2] value == 3)
 			list free()
 		})
 		this add("VectorList pass by reference", func {

--- a/test/collections/VectorListTest.ooc
+++ b/test/collections/VectorListTest.ooc
@@ -24,6 +24,12 @@ TestClass: class {
 	init: func(=_value)
 }
 
+extend VectorList <T> {
+	newMethod: func -> Int {
+		return 1
+	}
+}
+
 VectorTest: class extends Fixture {
 
 	sortFunc: static func (a,b: Int) -> Bool {
@@ -35,7 +41,7 @@ VectorTest: class extends Fixture {
 		a value > b value
 	}
 	passByRef: static func (vec: VectorList<Int>@) -> Int {
-		vec[0]
+		vec count
 	}
 	init: func {
 		super("VectorList")
@@ -177,6 +183,11 @@ VectorTest: class extends Fixture {
 			list := VectorList<Int> new()
 			list add(1)
 			expect(passByRef(list&) == 1)
+			list free()
+		})
+		this add("VectorList test extended class", func {
+			list := VectorList<Float> new()
+			expect(list newMethod() == 1)
 			list free()
 		})
 	}

--- a/test/collections/VectorListTest.ooc
+++ b/test/collections/VectorListTest.ooc
@@ -19,6 +19,12 @@ use ooc-unit
 use ooc-collections
 
 VectorTest: class extends Fixture {
+
+	sortFunc: static func (a,b: Int) -> Bool {
+		result := a > b
+		"arguments to sortFunc %i, %i : %i" format(a,b,result) println()
+		result
+	}
 	init: func {
 		super("VectorList")
 		this add("VectorList cover create", func {
@@ -132,6 +138,12 @@ VectorTest: class extends Fixture {
 			expect(newList[1], is equal to(2))
 			list free()
 			indices free()
+		})
+		this add("VectorList apply and sort", func {
+			list := VectorList<Int> new()
+			list add(0)
+			list add(2)
+			list sort(sortFunc)
 		})
 	}
 }

--- a/test/collections/VectorListTest.ooc
+++ b/test/collections/VectorListTest.ooc
@@ -18,12 +18,21 @@
 use ooc-unit
 use ooc-collections
 
+TestClass: class {
+	_value := 0
+	value ::= _value
+	init: func(=_value)
+}
+
 VectorTest: class extends Fixture {
 
 	sortFunc: static func (a,b: Int) -> Bool {
 		result := a > b
 		"arguments to sortFunc %i, %i : %i" format(a,b,result) println()
 		result
+	}
+	sortFuncClass: static func (a,b: TestClass) -> Bool {
+		a value > b value
 	}
 	init: func {
 		super("VectorList")
@@ -140,10 +149,12 @@ VectorTest: class extends Fixture {
 			indices free()
 		})
 		this add("VectorList apply and sort", func {
-			list := VectorList<Int> new()
-			list add(0)
-			list add(2)
-			list sort(sortFunc)
+			list := VectorList<TestClass> new()
+			list add(TestClass new(1))
+			list add(TestClass new(3))
+			list add(TestClass new(2))
+			list sort(sortFuncClass)
+			list free()
 		})
 	}
 }

--- a/test/collections/VectorListTest.ooc
+++ b/test/collections/VectorListTest.ooc
@@ -34,6 +34,9 @@ VectorTest: class extends Fixture {
 	sortFuncClass: static func (a,b: TestClass) -> Bool {
 		a value > b value
 	}
+	passByRef: static func (vec: VectorList<Int>@) -> Int {
+		vec[0]
+	}
 	init: func {
 		super("VectorList")
 		this add("VectorList cover create", func {
@@ -154,6 +157,12 @@ VectorTest: class extends Fixture {
 			list add(TestClass new(3))
 			list add(TestClass new(2))
 			list sort(sortFuncClass)
+			list free()
+		})
+		this add("VectorList pass by reference", func {
+			list := VectorList<Int> new()
+			list add(1)
+			expect(passByRef(list&) == 1)
 			list free()
 		})
 	}


### PR DESCRIPTION
I'm creating a pull request so that you can see this branch.
There is a bug in VectorList::sort( func greaterThan ) method, rock generates incorrect C code for the arguments passed to sorting function. Addresses are passed instead of argument values.
Definition for the simple sorting function:
```ooc
sortFunc: static func (a,b: Int) -> Bool {
a > b
}
```
Here is the C code generated for the sorting function definition:
```C
lang_types__Bool ___test_collections_VectorListTest__VectorTest_sortFunc(lInt a, Int b){ ...
```
Everything is ok so far.
Now, here is the C code generated for the VectorList sort method, for the fragment which calls the comparison operator:
```ooc
((lang_types__Bool (*)(uint8_t*, uint8_t*, void*)) greaterThan.thunk)((uint8_t*) a, (uint8_t*) b, greaterThan.context)) { ...
```
You can clearly see that addresses are passed to the greaterThan() function.
Here is example output when running the "VectorListTest" from this branch:

> values in VectorList: 2 0
> addresses in VectorList: 348047904 348047872
> arguments to sortFunc 348047904, 348047872

```ooc
// from VectorList class
sort: func (greaterThan: Func (T, T) -> Bool) {
	inOrder := false
	while (!inOrder) {
		inOrder = true
		for (i in 0 .. count - 1) {
			a := this[i]
			b := this[i + 1]
			"values in VectorList: %i %i" format(a as Int, b as Int) println()
			"addresses in VectorList: %i %i" format(a& as Int, b& as Int) println()
			if (greaterThan(a,b)) {
				inOrder = false
				tmp := this[i]
				this[i] = this[i + 1]
				this[i + 1] = tmp
			}
		}
	}
}

// from VectorListTest
sortFunc: static func (a,b: Int) -> Bool {
	result := a > b
	"arguments to sortFunc %i, %i : %i" format(a,b,result) println()
	result
}
```

Maybe I'm wrong, but I think there is a bug here.