### PR TITLE
FloatVectorList: improved sorting performance and added fast median algorithm

### DIFF
--- a/source/collections/VectorList.ooc
+++ b/source/collections/VectorList.ooc
@@ -121,9 +121,14 @@ VectorList: class <T> {
 	}
 	getSlice: func (range: Range) -> This<T> {
 		result := This<T> new(range count)
-		result _count = range count
-		source := (this pointer as Long + (range min * (T size))) as Pointer
-		memcpy(result pointer, source, range count * (T size))
+		this getSliceInto(range, result&)
 		result
+	}
+	getSliceInto: func(range: Range, buffer: This<T>@) {
+		if (buffer _vector capacity < range count)
+			buffer _vector resize(range count)
+		buffer _count = range count
+		source := (this pointer as Long + (range min * (T size))) as Pointer
+		memcpy(buffer pointer, source, range count * (T size))
 	}
 }

--- a/source/collections/VectorList.ooc
+++ b/source/collections/VectorList.ooc
@@ -124,7 +124,7 @@ VectorList: class <T> {
 		this getSliceInto(range, result&)
 		result
 	}
-	getSliceInto: func(range: Range, buffer: This<T>@) {
+	getSliceInto: func (range: Range, buffer: This<T>@) {
 		if (buffer _vector capacity < range count)
 			buffer _vector resize(range count)
 		buffer _count = range count

--- a/source/collections/VectorList.ooc
+++ b/source/collections/VectorList.ooc
@@ -128,7 +128,7 @@ VectorList: class <T> {
 		if (buffer _vector capacity < range count)
 			buffer _vector resize(range count)
 		buffer _count = range count
-		source := (this pointer as Long + (range min * (T size))) as Pointer
+		source := (this _vector _backend + (range min * (T size))) as Pointer
 		memcpy(buffer pointer, source, range count * (T size))
 	}
 }

--- a/source/math/FloatVectorList.ooc
+++ b/source/math/FloatVectorList.ooc
@@ -249,8 +249,8 @@ FloatVectorList: class extends VectorList<Float> {
 		result := This new(this count)
 		windowBuffer := This new(windowSize)
 		start := -((windowSize - 1) / 2)
-		for (i in 0..this count) {
-			range := ((start..(start + windowSize - 1)) + i) clamp(0, this count-1)
+		for (i in 0 .. this count) {
+			range := ((start .. (start + windowSize - 1)) + i) clamp(0, this count-1)
 			this getSliceInto(range, (windowBuffer as VectorList<Float>)&)
 			result add((windowBuffer as This) fastMedian(0, range count - 1))
 		}
@@ -270,7 +270,7 @@ FloatVectorList: class extends VectorList<Float> {
 		pivotValue := array[pivot]
 		This _swap(array, pivot, end)
 		result := start
-		for (i in start..end)
+		for (i in start .. end)
 			if (array[i] < pivotValue) {
 				This _swap(array, result, i)
 				++result

--- a/source/math/FloatVectorList.ooc
+++ b/source/math/FloatVectorList.ooc
@@ -251,7 +251,7 @@ FloatVectorList: class extends VectorList<Float> {
 		start := -((windowSize - 1) / 2)
 		for (i in 0..this count) {
 			range := ((start..(start + windowSize - 1)) + i) clamp(0, this count-1)
-			this getSliceInto(range, windowBuffer&)
+			this getSliceInto(range, (windowBuffer as VectorList<Float>)&)
 			result add((windowBuffer as This) fastMedian(0, range count - 1))
 		}
 		windowBuffer free()

--- a/source/math/FloatVectorList.ooc
+++ b/source/math/FloatVectorList.ooc
@@ -238,22 +238,23 @@ FloatVectorList: class extends VectorList<Float> {
 	/* calculate median without copying and sorting the vector
 			WARNING: this function can partially rearange the elements in vector
 	*/
-	fastMedian: func -> Float {
-		data := this _vector _backend as Float*
-		result := This _nthElement(this _vector _backend as Float*, 0, this count - 1, this count / 2)
-		if (Int even(this count))
-			result = (result + This _nthElement(this _vector _backend as Float*, 0, this count - 1, this count / 2 - 1)) / 2
+	fastMedian: func (start := 0, end := this count - 1) -> Float {
+		count := end - start + 1
+		result := This _nthElement(this _vector _backend as Float*, start, end, count / 2)
+		if (Int even(count))
+			result = (result + This _nthElement(this _vector _backend as Float*, start, end, count / 2 - 1)) / 2
 		result
 	}
 	movingMedianFilter: func (windowSize: Int) -> This {
 		result := This new(this count)
+		windowBuffer := This new(windowSize)
 		start := -((windowSize - 1) / 2)
-		for (i in 0 .. this count) {
-			range := (start .. (start + windowSize - 1)) + i
-			elementsInWindow := this getSlice(range clamp(0, this count-1))
-			result add((elementsInWindow as This) fastMedian())
-			elementsInWindow free()
+		for (i in 0..this count) {
+			range := ((start..(start + windowSize - 1)) + i) clamp(0, this count-1)
+			this getSliceInto(range, windowBuffer&)
+			result add((windowBuffer as This) fastMedian(0, range count - 1))
 		}
+		windowBuffer free()
 		result
 	}
 	_swap: static func (array: Float*, i, j: Int) {

--- a/source/math/FloatVectorList.ooc
+++ b/source/math/FloatVectorList.ooc
@@ -65,19 +65,7 @@ FloatVectorList: class extends VectorList<Float> {
 	}
 	standardDeviation ::= this variance sqrt()
 	sort: func {
-		inOrder := false
-		vector := this _vector _backend as Float*
-		while (!inOrder) {
-			inOrder = true
-			for (i in 0 .. count - 1) {
-				if (vector[i] > vector[i + 1]) {
-					inOrder = false
-					tmp := vector[i]
-					vector[i] = vector[i + 1]
-					vector[i + 1] = tmp
-				}
-			}
-		}
+		This _quicksort(this _vector _backend as Float*, 0, this count - 1)
 	}
 	accumulate: func -> This {
 		result := This new(this _count)
@@ -247,15 +235,93 @@ FloatVectorList: class extends VectorList<Float> {
 		tempVector free()
 		result
 	}
+	/* calculate median without copying and sorting the vector
+			WARNING: this function can partially rearange the elements in vector
+	*/
+	fastMedian: func -> Float {
+		data := this _vector _backend as Float*
+		result := This _nthElement(this _vector _backend as Float*, 0, this count - 1, this count / 2)
+		if (Int even(this count))
+			result = (result + This _nthElement(this _vector _backend as Float*, 0, this count - 1, this count / 2 - 1)) / 2
+		result
+	}
 	movingMedianFilter: func (windowSize: Int) -> This {
 		result := This new(this count)
 		start := -((windowSize - 1) / 2)
 		for (i in 0 .. this count) {
 			range := (start .. (start + windowSize - 1)) + i
 			elementsInWindow := this getSlice(range clamp(0, this count-1))
-			result add((elementsInWindow as This) median())
+			result add((elementsInWindow as This) fastMedian())
 			elementsInWindow free()
 		}
 		result
+	}
+	_swap: static func (array: Float*, i, j: Int) {
+		t := array[i]
+		array[i] = array[j]
+		array[j] = t
+	}
+	/* partition the array so that all elements less than array[pivot] are moved before this element
+		and all elements greater than array[pivot] are after it
+		end should be the last valid array index in the range
+	*/
+	_partition: static func (array: Float*, start, end, pivot: Int) -> Int {
+		pivotValue := array[pivot]
+		This _swap(array, pivot, end)
+		result := start
+		for (i in start..end)
+			if (array[i] < pivotValue) {
+				This _swap(array, result, i)
+				++result
+			}
+		This _swap(array, result, end)
+		result
+	}
+	/*
+	pivot selection strategy which should result in best performance
+	for quicksort and nthElement algorithms on partially sorted data
+		end should be the last valid array index in the range
+	*/
+	_medianOfThree: static func (array: Float*, start, end: Int) -> Int {
+		mid := (start + end) / 2
+		if (array[start] > array[mid])
+			This _swap(array, mid, start)
+		if (array[mid] > array[end])
+			This _swap(array, mid, end)
+		if (array[start] > array[end])
+			This _swap(array, start, end)
+		mid
+	}
+
+	/* return n-th smallest element in the array[start:end] range
+		end should be the last valid array index in the range
+	*/
+	_nthElement: static func (array: Float*, start, end, n: Int) -> Float {
+		if (start == end)
+			array[start]
+		else {
+			pivot := This _partition(array, start, end, This _medianOfThree(array, start, end))
+			if (pivot == n)
+				array[n]
+			else if (n < pivot)
+				_nthElement(array, start, pivot - 1, n)
+			else
+				_nthElement(array, pivot + 1, end, n)
+		}
+	}
+
+	/* sort the input array in the range [start,end]
+		end should be the last valid array index in the range
+	*/
+	_quicksort: static func (array: Float*, start, end: Int) {
+		if (end == start + 1 && array[start] > array[end])
+			This _swap(array, start, end)
+		else if (start < end) {
+			pivot := This _partition(array, start, end, This _medianOfThree(array, start, end))
+			if (pivot > start)
+				This _quicksort(array, start, pivot - 1)
+			if (pivot < end)
+				This _quicksort(array, pivot + 1, end)
+		}
 	}
 }


### PR DESCRIPTION
Implementation of quicksort and quickselect for float vectors.
It is not a general implementation (based on generics or iterators, with a custom comparator function) because of #327 .
Profiling and testing is on my branch https://github.com/sebastianbaginski/ooc-kean/tree/quickselectProfiling  (run *./test.sh math/FloatVectorList*)

Example profiling results:
> start testing new: 10:20:22
> done testing new: 10:20:26
> start testing old: 10:20:26
> done testing old: 10:26:20
> number of tests: 20000

calculating median and sorting for 20.000 random float vectors of length 1000 took ~4 seconds with new implementation vs. ~6 minutes with old.