### PR TITLE
Removed compilation warning

### DIFF
--- a/source/draw/gpu/opengl/OpenGLES3/ShaderProgram.ooc
+++ b/source/draw/gpu/opengl/OpenGLES3/ShaderProgram.ooc
@@ -18,6 +18,8 @@
 use ooc-math
 import include/gles, DebugGL
 
+CONST_CHAR_CAST: extern func (CString*) -> const CString*
+
 ShaderProgram: class {
 	_backend: UInt
 	init: func
@@ -157,7 +159,7 @@ ShaderProgram: class {
 	_glCompileShader: func (shaderID: UInt) { glCompileShader(shaderID) }
 	_compileShader: func (source: String, shaderID: UInt) -> Bool {
 		version(debugGL) { validateStart() }
-		glShaderSource(shaderID, 1, (source toCString())&, null)
+		glShaderSource(shaderID, 1, CONST_CHAR_CAST((source toCString()&)), null)
 		this _glCompileShader(shaderID)
 
 		success: Int

--- a/source/sdk/lang/Array.h
+++ b/source/sdk/lang/Array.h
@@ -14,6 +14,7 @@
 
 
 #define _lang_array__Array_new(type, size) ((_lang_array__Array) { size, array_malloc((size) * sizeof(type)) });
+#define CONST_CHAR_CAST(x) (const char* const*) (x)
 
 #if defined(safe)
 #define _lang_array__Array_get(array, index, type) ( \
@@ -41,4 +42,3 @@ typedef struct {
 } _lang_array__Array;
 
 #endif // ___lang_array___
-


### PR DESCRIPTION
This fixes the compilation warning
> ShaderProgram.ooc:160:5: warning: passing argument 3 of ‘glShaderSource’ from incompatiblepointer type [enabled by default]
>   glShaderSource(shaderID, 1, (source toCString())&, null)

