### PR TITLE
An alternative version of PR #344.

### DIFF
--- a/source/draw/gpu/opengl/OpenGLES3/ShaderProgram.ooc
+++ b/source/draw/gpu/opengl/OpenGLES3/ShaderProgram.ooc
@@ -157,7 +157,7 @@ ShaderProgram: class {
 	_glCompileShader: func (shaderID: UInt) { glCompileShader(shaderID) }
 	_compileShader: func (source: String, shaderID: UInt) -> Bool {
 		version(debugGL) { validateStart() }
-		glShaderSource(shaderID, 1, (source toCString())&, null)
+		glShaderSource(shaderID, 1, String toConstCharPointerConstPointer(source toCString()&), null)
 		this _glCompileShader(shaderID)
 
 		success: Int

--- a/source/sdk/lang/String.ooc
+++ b/source/sdk/lang/String.ooc
@@ -1,3 +1,11 @@
+include ./StringExtension
+
+extend String {
+    // This function only exists to silence a warning when calling OpenGL's glShaderSource function.
+    // It requires a const char * const * argument, but since ooc doesn't have const, we need to
+    // cast the char * into a const char * const * by using this C macro, defined in StringExtension.h.
+    toConstCharPointerConstPointer: static extern(CONST_CHAR_POINTER_CONST_POINTER_CAST) func (CString*) -> const CString*
+}
 
 /**
  * The String class represents character strings.

--- a/source/sdk/lang/StringExtension.h
+++ b/source/sdk/lang/StringExtension.h
@@ -1,0 +1,1 @@
+#define CONST_CHAR_POINTER_CONST_POINTER_CAST(x) (const char* const*) (x)


### PR DESCRIPTION
The obvious backdraw here is that a static function is used. It would be much better off as a member function, but I don't know how the macro should be written, then. Notably, the result of the macro must be used immediately, because if it passes through an ooc function on the way, it becomes a normal char ** again. @sebastianbaginski, any ideas?