### PR TITLE
fixed an error in map()

### DIFF
--- a/source/collections/VectorList.ooc
+++ b/source/collections/VectorList.ooc
@@ -118,7 +118,7 @@ VectorList: class <T> {
 	map: func <T, S> (function: Func(T) -> S) -> This<S> {
 		result := This<S> new(this count)
 		for (i in 0 .. this count) {
-			result[i] = function(this[i])
+			result add(function(this[i]))
 		}
 		result
 	}


### PR DESCRIPTION
```result[i] = function(this[i])``` does not update the list count, thus causing the resulting vector list to be in an invalid state.