### PR TITLE
Added methods to copy row and column of raster image to given buffer

### DIFF
--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -189,7 +189,7 @@ RasterMonochrome: class extends RasterPacked {
 
 	getValue: func (x, y: Int) -> UInt8 {
 		version(safe) {
-			if (x > this size width || y > this size height || x < 0 || y < 0)
+			if (x >= this size width || y >= this size height || x < 0 || y < 0)
 				raise("Accessing RasterMonochrome index out of range in getValue")
 		}
 		(this buffer pointer[y * this stride + x])
@@ -197,30 +197,35 @@ RasterMonochrome: class extends RasterPacked {
 
 	operator []= (x, y: Int, value: ColorMonochrome) {
 		version(safe) {
-			if (x > this size width || y > this size height || x < 0 || y < 0)
+			if (x >= this size width || y >= this size height || x < 0 || y < 0)
 				raise("Accessing RasterMonochrome index out of range in set operator")
 		}
 		((this buffer pointer + y * this stride) as ColorMonochrome* + x)@ = value
 	}
-	getRow: func (y: Int) -> FloatVectorList {
-		result := FloatVectorList new()
-		version(safe) {
-			if (y > this size height || y < 0)
-				raise("Accessing RasterMonochrome index out of range in getRow")
-		}
-		for (x in 0 .. (this size width))
-				result add(this buffer pointer[y * this stride + x] as Float)
+	getRow: func (row: Int) -> FloatVectorList {
+		result := FloatVectorList new(this size width)
+		this getRowInto(row, result)
 		result
 	}
-
-	getColumn: func (x: Int) -> FloatVectorList {
-		result := FloatVectorList new()
+	getRowInto: func (row: Int, vector: FloatVectorList) {
 		version(safe) {
-			if (x > this size width || x < 0)
+			if (row >= this size height || row < 0)
+				raise("Accessing RasterMonochrome index out of range in getRow")
+		}
+		for (column in 0 .. this size width)
+			vector add(this buffer pointer[row * this stride + column] as Float)
+	}
+	getColumn: func (column: Int) -> FloatVectorList {
+		result := FloatVectorList new(this size height)
+		this getColumnInto(column, result)
+		result
+	}
+	getColumnInto: func (column: Int, vector: FloatVectorList) {
+		version(safe) {
+			if (column >= this size width || column < 0)
 				raise("Accessing RasterMonochrome index out of range in getColumn")
 		}
-		for (y in 0 .. (this size height))
-				result add(this buffer pointer[y * this stride + x] as Float)
-		result
+		for (row in 0 .. this size height)
+			vector add(this buffer pointer[row * this stride + column] as Float)
 	}
 }

--- a/test/draw/RasterMonochromeTest.ooc
+++ b/test/draw/RasterMonochromeTest.ooc
@@ -38,6 +38,25 @@ RasterMonochromeTest: class extends Fixture {
 			expect(image1 equals(image2))
 			image1 free(); image2 free()
 		})
+		this add("getRow and getColumn", func{
+			size := IntSize2D new(500, 256)
+			image := RasterMonochrome new(size)
+			for (row in 0 .. size height)
+				for (column in 0 .. size width)
+					image[column, row] = ColorMonochrome new(row)
+			for (column in 0 .. size width) {
+				columnData := image getColumn(column)
+				expect(columnData count == size height)
+				for (i in 0 .. columnData count)
+					expect(columnData[i] as UInt8 == i)
+			}
+			for (row in 0 .. size height) {
+				rowData := image getRow(row)
+				expect(rowData count == size width)
+				for (i in 0 .. rowData count)
+					expect(rowData[i] as UInt8 == row)
+			}
+		})
 		/*this add("distance, convertFrom RasterBgra", func {
 			source := this sourceFlower
 			output := "test/draw/output/RasterBgrToMonochrome.png"


### PR DESCRIPTION
Fixed naming conventions.
Fixed possible bug - it was possible to access non existing row or column in *safe* version.