### PR TITLE
updated Fixture to flush output buffer for interactive display

### DIFF
--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -33,7 +33,7 @@ Fixture: abstract class {
 	run: func {
 		failures := ArrayList<TestFailedException> new()
 		result := true
-		(this name + " ") print()
+		This _print(this name + " ")
 		this tests each(|test|
 			r := true
 			try {
@@ -44,9 +44,9 @@ Fixture: abstract class {
 				result = r = false
 				failures add(e)
 			}
-			(r ? "." : "f") print()
+			This _print(r ? "." : "f")
 		)
-		(result ? " done" : " failed") println()
+		This _print(result ? " done\n" : " failed\n")
 		if (!result)
 			for (f in failures) {
 				// If the constraint is a CompareConstraint and the value being tested is a Cell,
@@ -102,6 +102,10 @@ Fixture: abstract class {
 	}
 	expect: static func ~isTrue (value: Bool) {
 		This expect(Cell new(value), is true)
+	}
+	_print: static func (string: String) {
+		string print()
+		fflush(stdout)
 	}
 }
 TestFailedException: class extends Exception {


### PR DESCRIPTION
I think it looks nice for tests which takes some time to run, like gpu, image or random generator tests. The *dots* will be displayed one after another, instead of having the string `Class ..... done` displayed at once after the test is done.
@davidhesselbom @thomasfanell 