### PR TITLE
Fixed compilation on Android

### DIFF
--- a/source/sdk/threading/native/ThreadUnix.ooc
+++ b/source/sdk/threading/native/ThreadUnix.ooc
@@ -39,7 +39,11 @@ version(unix || apple) {
         }
 
         cancel: func -> Bool {
-            this alive?() && (pthread_cancel(this pthread) == 0)
+          version (android) {
+            Exception new(This, "Unsupported platform!\n") throw()
+          } else
+            return this alive?() && (pthread_cancel(this pthread) == 0)
+          false
         }
 
         alive?: func -> Bool {


### PR DESCRIPTION
@emilwestergren found out that we cannot use `pthread_cancel` on android. This is his fix for the compilation issues.