### PR TITLE
fixed possible deadlock in thread test

### DIFF
--- a/test/sdk/ThreadTest.ooc
+++ b/test/sdk/ThreadTest.ooc
@@ -27,6 +27,7 @@ ThreadTest: class extends Fixture {
 		mutex := Mutex new()
 		startedCondition := WaitCondition new()
 		job := func {
+			mutex lock()
 			startedCondition broadcast()
 			mutex unlock()
 			while (value get() < expectedValue) {
@@ -42,8 +43,8 @@ ThreadTest: class extends Fixture {
 		thread free()
 		value set(0)
 		thread = Thread new(|| job())
-		expect(thread start())
 		mutex lock()
+		expect(thread start())
 		startedCondition wait(mutex)
 		expect(thread cancel())
 		expect(thread wait())


### PR DESCRIPTION
It was possible for `startedCondition` to broadcast a signal even before the main thread started to wait for it, resulting in a deadlock. `startedCondition wait(mutex)` call will now put the main thread to sleep and release the mutex before the wait condition sends the *wake up* signal.