### PR TITLE
WaitCondition implementation for Windows

### DIFF
--- a/source/sdk/threading/Thread.ooc
+++ b/source/sdk/threading/Thread.ooc
@@ -1,7 +1,7 @@
 import native/[ThreadUnix, ThreadWin32]
 import native/[MutexUnix, MutexWin32]
 import native/[ThreadLocalUnix, ThreadLocalWin32]
-import native/ConditionUnix
+import native/[ConditionUnix, ConditionWin32]
 
 /**
  * A thread is a thread of execution in a program. Multiple threads
@@ -296,6 +296,9 @@ WaitCondition: abstract class {
     new: static func -> This {
         version (unix || apple) {
             return ConditionUnix new() as This
+        }
+        version (windows) {
+            return ConditionWin32 new() as This
         }
         Exception new(This, "Unsupported platform!\n") throw()
         null

--- a/source/sdk/threading/native/ConditionWin32.ooc
+++ b/source/sdk/threading/native/ConditionWin32.ooc
@@ -1,0 +1,87 @@
+version(windows) {
+
+	import ../Thread
+	import native/win32/[types, errors]
+	import MutexWin32
+	import structs/ArrayList
+
+	include windows
+
+	CreateEvent: extern func (...) -> Handle
+	SetEvent: extern func (Handle) -> Bool
+	CloseHandle: extern func (Handle) -> Bool
+	Infinite: extern (INFINITE) Long
+	WaitSuccess: extern (WAIT_OBJECT_0) Long
+
+	ConditionWin32: class extends WaitCondition {
+		_mutex := Mutex new()
+		_waitingEvents := ArrayList<Handle> new()
+		_waitingForRelease := ArrayList<Handle> new()
+		init: func
+		free: override func {
+			this destroy()
+			this _waitingEvents free()
+			this _waitingForRelease free()
+			this _mutex destroy()
+			super()
+		}
+		wait: func (mutex: Mutex) -> Bool {
+			eventId := CreateEvent(null, false, false, null)
+			this _mutex lock()
+			this _waitingEvents add(eventId)
+			this _mutex unlock()
+			mutex unlock()
+			(WaitForSingleObject(eventId, Infinite) == WaitSuccess)
+		}
+		signal: func -> Bool {
+			result := false
+			toSignal := 0 as Handle
+			this _mutex lock()
+			if (this _waitingEvents size > 0) {
+				toSignal = this _waitingEvents first()
+				this _waitingEvents removeAt(0)
+				this _waitingForRelease add(toSignal)
+			}
+			this _mutex unlock()
+			if (toSignal != 0)
+				result = SetEvent(toSignal)
+			result
+		}
+		broadcast: func -> Bool {
+			result := false
+			toSignal := ArrayList<Handle> new()
+			this _mutex lock()
+			while (this _waitingEvents size > 0) {
+				eventId := this _waitingEvents first()
+				this _waitingEvents removeAt(0)
+				this _waitingForRelease add(eventId)
+				toSignal add(eventId)
+			}
+			this _mutex unlock()
+			if (toSignal size > 0) {
+				result = true
+				for (i in 0 .. toSignal size)
+					result = result && SetEvent(toSignal[i])
+			}
+			toSignal free()
+			result
+		}
+		// do not destroy wait condition while threads are still waiting on it
+		destroy: func -> Bool {
+			this _mutex lock()
+			//waiting threads should have a chance to wake up
+			for (i in 0 .. this _waitingEvents size) {
+				SetEvent(this _waitingEvents[i])
+				Thread yield()
+			}
+			for (i in 0 .. this _waitingForRelease size)
+				CloseHandle(this _waitingForRelease[i])
+			for (i in 0 .. this _waitingEvents size)
+				CloseHandle(this _waitingEvents[i])
+			this _waitingEvents clear()
+			this _waitingForRelease clear()
+			this _mutex unlock()
+			true
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/cogneco/ooc-kean/issues/407 .
WaitCondition implementation for win32 based on event objects.
It could be easier to use condition variables (https://msdn.microsoft.com/en-us/library/windows/desktop/ms682052%28v=vs.85%29.aspx) but they are supported only from Vista and above, and they didn't work with msys2 (outdated headers and libraries I guess).
This implementation requires some manual bookkeeping. We need to keep the list of events that are waiting on the wait condition and then manually manipulate this list when we broadcast a *wake up* signal.
I do not have a good idea about when to free created events. We cannot do that after sending the *wake up* signal, as we can't know when it will be delivered, and destroying an event while it is still processed is not what we want (possible deadlock). Maybe we could test the sent events with `WaitForSingleObject` with very short timeout before we queue new events.
Right now event objects are freed when the wait condition is released, so it is not a good idea to destroy the wait condition while threads are still waiting on it.
Anyway, it seems to be working on windows (thanks @jonathanudd for all the help with testing :)), so I guess it is good enough for now.