### PR TITLE
Improved limit externs in Numbers.ooc.

### DIFF
--- a/source/sdk/lang/Numbers.ooc
+++ b/source/sdk/lang/Numbers.ooc
@@ -55,19 +55,14 @@ UInt:   cover from unsigned int   extends ULLong {
 }
 UShort: cover from unsigned short extends ULLong
 
-//INT_MIN,    INT_MAX  : extern const static Int
-//UINT_MAX           : extern const static UInt
-//LONG_MIN,  LONG_MAX  : extern const static Long
-//ULONG_MAX          : extern const static ULong
-//LLONG_MIN, LLONG_MAX : extern const static LLong
-ULLONG_MAX             : extern const static ULLong
-
-INT_MAX := 2147483647
-INT_MIN := -INT_MAX - 1
-INFINITY: extern Double
-NAN: extern Double
-FLT_MIN: extern Float
-DBL_MIN: extern Double
+SHRT_MIN, SHRT_MAX: extern static Short
+USHRT_MAX: extern static UShort
+INT_MIN, INT_MAX: extern static Int
+UINT_MAX: extern static UInt
+LONG_MIN, LONG_MAX: extern static Long
+ULONG_MAX: extern static ULong
+LLONG_MIN, LLONG_MAX: extern static LLong
+ULLONG_MAX: extern static ULLong
 
 /**
  * fixed-size integer types
@@ -110,9 +105,9 @@ Float: cover from float extends LDouble {
     }
 }
 
-DBL_MIN,  DBL_MAX : extern static const Double
-FLT_MIN,  FLT_MAX : extern static const Float
-LDBL_MIN, LDBL_MAX: extern static const LDouble
+FLT_MIN, FLT_MAX: extern static Float
+DBL_MIN, DBL_MAX, INFINITY, NAN: extern static Double
+LDBL_MIN, LDBL_MAX: extern static LDouble
 
 /**
  * custom types


### PR DESCRIPTION
This was recently fixed in the original SDK.