### PR TITLE
Removed dependancy on sdk random

### DIFF
--- a/test/plot/SvgPlotTest.ooc
+++ b/test/plot/SvgPlotTest.ooc
@@ -4,7 +4,6 @@ use ooc-math
 use ooc-collections
 use ooc-draw
 import math
-import math/Random
 import io/File
 
 log := VectorList<FloatPoint2D> new()
@@ -15,13 +14,14 @@ unitCircle := VectorList<FloatPoint2D> new()
 scatter := VectorList<FloatPoint2D> new()
 parabola := VectorList<FloatPoint2D> new()
 sparseParabola := VectorList<FloatPoint2D> new()
+randomGenerator := IntUniformRandomGenerator new(0, 100)
 for (i in -200 .. 201) {
 	log add(FloatPoint2D new((201 + i as Float) * 100, log((201 + i as Float)) * 100))
 	sin add(FloatPoint2D new(i as Float / 20, sin(i as Float / 20)))
 	cos add(FloatPoint2D new(i as Float / 20, cos(i as Float / 20)))
 	sinMinusCos add(FloatPoint2D new(i as Float / 20, sin(i as Float / 20) - cos(i as Float / 20)))
 	unitCircle add(FloatPoint2D new(i as Float / 200, sqrt(1 - pow(i as Float / 200, 2))))
-	scatter add(FloatPoint2D new(Random randInt(0, 100) as Float, Random randInt(0, 100) as Float))
+	scatter add(FloatPoint2D new(randomGenerator next() as Float, randomGenerator next() as Float))
 	parabola add(FloatPoint2D new(i as Float / 20, pow(i as Float / 20, 2)))
 }
 for (i in -200 .. 201) {
@@ -29,6 +29,7 @@ for (i in -200 .. 201) {
 	if (i % 50 == 0)
 		sparseParabola add(FloatPoint2D new(i as Float / 20, pow(i as Float / 20, 2)))
 }
+randomGenerator free()
 
 // Simplest use-case with line plot
 logData := LinePlotData2D new(log, "log(x)")


### PR DESCRIPTION
Code should from now on use the Int/Float RandomGenerators wherever applicable instead of Random in the sdk. This was the only use of it I could find in kean.