### PR TITLE
Add limits.h header on Windows for numeric constants

### DIFF
--- a/source/sdk/lang/Numbers.ooc
+++ b/source/sdk/lang/Numbers.ooc
@@ -1,4 +1,7 @@
 include stdlib, stdint, stddef, float, ctype, sys/types
+version(windows) {
+  include limits
+}
 
 LLong: cover from signed long long {
 


### PR DESCRIPTION
Current version of kean can't be compiled on Windows, as `INT_MIN` and `INT_MAX` constants are defined in `<limits.h>`.