### PR TITLE
Fixes in ImageFileTest and RasterYuv420Semiplanar

### DIFF
--- a/source/draw/RasterBgra.ooc
+++ b/source/draw/RasterBgra.ooc
@@ -37,22 +37,23 @@ RasterBgra: class extends RasterPacked {
 		result
 	}
 	apply: func ~bgr (action: Func(ColorBgr)) {
-		end := this buffer pointer as Long + this buffer size
-		rowLength := this size width * this bytesPerPixel
-		for (row: Long in this buffer pointer as Long .. end) {
-			rowEnd := row + rowLength
-			for (source: Long in row .. rowEnd) {
-				action((source as ColorBgr*)@)
-				source += 3
+		for (row in 0 .. this size height) {
+			source := this buffer pointer + row * this stride
+			for (pixel in 0 .. this size width) {
+				pixelPointer := (source + pixel * this bytesPerPixel) as ColorBgr*
+				action(pixelPointer@)
 			}
-			row += this stride - 1
 		}
 	}
 	apply: func ~yuv (action: Func(ColorYuv)) {
-		this apply(ColorConvert fromBgr(action))
+		convert := ColorConvert fromBgr(action)
+		this apply(convert)
+		(convert as Closure) dispose()
 	}
 	apply: func ~monochrome (action: Func(ColorMonochrome)) {
-		this apply(ColorConvert fromBgr(action))
+		convert := ColorConvert fromBgr(action)
+		this apply(convert)
+		(convert as Closure) dispose()
 	}
 	distance: func (other: Image) -> Float {
 		result := 0.0f
@@ -144,6 +145,7 @@ RasterBgra: class extends RasterPacked {
 			}
 		}
 		original apply(f)
+		(f as Closure) dispose()
 		result
 	}
 	operator [] (x, y: Int) -> ColorBgra { this isValidIn(x, y) ? ((this buffer pointer + y * this stride) as ColorBgra* + x)@ : ColorBgra new(0, 0, 0, 0) }

--- a/test/draw/ImageFileTest.ooc
+++ b/test/draw/ImageFileTest.ooc
@@ -16,6 +16,7 @@ ImageFileTest: class extends Fixture {
 		})
 		this add("open PNG", func {
 			source := "test/draw/input/Space.png"
+			expect(This _fileExists(source))
 			destination := "test/draw/output/outputPNG.png"
 			requiredComponents := 4
 			x, y, n: Int
@@ -33,9 +34,11 @@ ImageFileTest: class extends Fixture {
 				failureReason = StbImage failureReason()
 				failureReason toString() println()
 			}
-		})/*
+			expect(This _fileExists(destination))
+		})
 		this add("open JPEG", func {
 			source := "test/draw/input/Flower.jpg"
+			expect(This _fileExists(source))
 			destination := "test/draw/output/outputJPEG.png"
 			requiredComponents := 4
 			x, y, n: Int
@@ -53,42 +56,56 @@ ImageFileTest: class extends Fixture {
 				failureReason = StbImage failureReason()
 				failureReason toString() println()
 			}
-		})*/
+			expect(This _fileExists(destination))
+		})
 		this add("open png RasterBgra", func {
 			source := "test/draw/input/Space.png"
 			destination := "test/draw/output/pngRasterBgra.png"
+			expect(This _fileExists(source))
 			image := RasterBgra open(source)
 			image save(destination)
+			expect(This _fileExists(destination))
+			image free()
 		})
 		this add("open png RasterBgr", func {
 			source := "test/draw/input/Space.png"
 			destination := "test/draw/output/pngRasterBgr.png"
 			image := RasterBgr open(source)
 			image save(destination)
+			expect(This _fileExists(destination))
+			image free()
 		})
-		/*this add("open png RasterMonochrome", func {
+		this add("open png RasterMonochrome", func {
 			source := "test/draw/input/Barn.png"
 			destination := "test/draw/output/pngRasterMonochrome.png"
 			image := RasterMonochrome open(source)
 			image save(destination)
+			expect(This _fileExists(destination))
+			image free()
 		})
 		this add("open jpg RasterBgra", func {
 			source := "test/draw/input/Hercules.jpg"
 			destination := "test/draw/output/jpgRasterBgra.png"
 			image := RasterBgra open(source)
 			image save(destination)
+			expect(This _fileExists(destination))
+			image free()
 		})
 		this add("open jpg RasterBgr", func {
 			source := "test/draw/input/Hercules.jpg"
 			destination := "test/draw/output/jpgRasterBgr.png"
 			image := RasterBgr open(source)
 			image save(destination)
-		})*/
+			expect(This _fileExists(destination))
+			image free()
+		})
 		this add("open jpg RasterMonochrome", func {
 			source := "test/draw/input/Hercules.jpg"
 			destination := "test/draw/output/jpgRasterMonochrome.png"
 			image := RasterMonochrome open(source)
 			image save(destination)
+			expect(This _fileExists(destination))
+			image free()
 		})
 		this add("convert RasterMonochrome to RasterBgra", func {
 			source := "test/draw/input/Space.jpg"
@@ -96,6 +113,9 @@ ImageFileTest: class extends Fixture {
 			monochrome := RasterMonochrome open(source)
 			bgra := RasterBgra convertFrom(monochrome)
 			bgra save(destination)
+			expect(This _fileExists(destination))
+			monochrome free()
+			bgra free()
 		})
 		this add("convert RasterBgra to RasterMonochrome", func {
 			source := "test/draw/input/Space.png"
@@ -103,6 +123,9 @@ ImageFileTest: class extends Fixture {
 			bgra := RasterBgra open(source)
 			monochrome := RasterMonochrome convertFrom(bgra)
 			monochrome save(destination)
+			expect(This _fileExists(destination))
+			monochrome free()
+			bgra free()
 		})
 		this add("convert RasterBgr to RasterMonochrome", func {
 			source := "test/draw/input/Hercules.png"
@@ -110,6 +133,9 @@ ImageFileTest: class extends Fixture {
 			bgr := RasterBgr open(source)
 			monochrome := RasterMonochrome convertFrom(bgr)
 			monochrome save(destination)
+			expect(This _fileExists(destination))
+			bgr free()
+			monochrome free()
 		})
 		this add("convert RasterMonochrome to RasterBgr", func {
 			source := "test/draw/input/Hercules.png"
@@ -117,6 +143,8 @@ ImageFileTest: class extends Fixture {
 			monochrome := RasterMonochrome open(source)
 			bgr := RasterBgr convertFrom(monochrome)
 			bgr save(destination)
+			expect(This _fileExists(destination))
+			bgr free()
 		})
 		this add("convert RasterBgr to RasterBgra", func {
 			source := "test/draw/input/Hercules.png"
@@ -124,6 +152,9 @@ ImageFileTest: class extends Fixture {
 			bgr := RasterBgr open(source)
 			bgra := RasterBgra convertFrom(bgr)
 			bgra save(destination)
+			expect(This _fileExists(destination))
+			bgr free()
+			bgra free()
 		})
 		this add("convert RasterBgra to RasterBgr", func {
 			source := "test/draw/input/Hercules.png"
@@ -131,15 +162,10 @@ ImageFileTest: class extends Fixture {
 			bgra := RasterBgra open(source)
 			bgr := RasterBgr convertFrom(bgra)
 			bgr save(destination)
+			expect(This _fileExists(destination))
+			bgr free()
+			bgra free()
 		})
-/*		this add("convert RasterBgra to RasterYuv420Planar to RasterMonochrome", func {
-			source := "test/draw/input/Barn.png"
-			destination := "test/draw/output/RasterBgra-RasterYuv420Planar-RasterMonochrome.png"
-			bgra := RasterBgra open(source)
-			yuv420 := RasterYuv420Planar new(bgra)
-			monochrome := RasterMonochrome new(yuv420)
-			monochrome save(destination)
-		})*/
 		this add("convert RasterBgra to RasterYuv420Semiplanar", func {
 			source := "test/draw/input/Barn.png"
 			destination := "test/draw/output/RasterBgra-RasterYuv420Semiplanar-RasterMonochrome.png"
@@ -147,23 +173,11 @@ ImageFileTest: class extends Fixture {
 			yuv420 := RasterYuv420Semiplanar convertFrom(bgra)
 			monochrome := RasterMonochrome convertFrom(yuv420)
 			monochrome save(destination)
+			expect(This _fileExists(destination))
+			monochrome free()
+			yuv420 free()
+			bgra free()
 		})
-/*		this add("convert RasterBgr to RasterYuv420Planar to RasterMonochrome", func {
-			source := "test/draw/input/Barn.png"
-			destination := "test/draw/output/RasterBgr-RasterYuv420Planar-RasterMonochrome.png"
-			bgr := RasterBgr open(source)
-			yuv420 := RasterYuv420Planar new(bgr)
-			monochrome := RasterMonochrome new(yuv420)
-			monochrome save(destination)
-		})
-		this add("convert RasterBgr to RasterYuv420Planar and back again", func {
-			source := "test/draw/input/Barn.png"
-			destination := "test/draw/output/RasterBgr-RasterYuv420Planar-RasterBgr.png"
-			bgr := RasterBgr open(source)
-			yuv420 := RasterYuv420Planar new(bgr)
-			bgr2 := RasterBgr new(yuv420)
-			bgr2 save(destination)
-		})*/
 		this add("convert RasterBgra to RasterYuv420Semiplanar and back again", func {
 			source := "test/draw/input/Flower.png"
 			destination := "test/draw/output/RasterBgr-RasterYuv420Semiplanar-RasterBgr.png"
@@ -171,25 +185,39 @@ ImageFileTest: class extends Fixture {
 			semiplanar := RasterYuv420Semiplanar convertFrom(bgr)
 			bgr2 := RasterBgr convertFrom(semiplanar)
 			bgr2 save(destination)
+			expect(This _fileExists(destination))
+			bgr2 free()
 		})
 		this add("Open and save RasterYuv420Semiplanar", func {
 			source := "test/draw/input/Flower.png"
 			destination := "test/draw/output/RasterYuv420Semiplanar.png"
 			semiplanar := RasterYuv420Semiplanar open(source)
 			semiplanar save(destination)
+			expect(This _fileExists(destination))
+			semiplanar free()
 		})
 		this add("save to bin", func {
 			source := "test/draw/input/Flower.png"
 			destination := "test/draw/output/Flower.bin"
 			semiplanar := RasterYuv420Semiplanar open(source)
 			semiplanar saveRaw(destination)
+			expect(This _fileExists(destination))
+			semiplanar free()
 		})
 		this add("load from bin", func {
 			source := "test/draw/output/Flower.bin"
 			destination := "test/draw/output/FromBinary.png"
 			semiplanar := RasterYuv420Semiplanar openRaw(source, IntSize2D new(636, 424))
 			semiplanar save(destination)
+			expect(This _fileExists(destination))
+			semiplanar free()
 		})
+	}
+	_fileExists: static func (path: String) -> Bool {
+		file := File new(path)
+		result := file exists?()
+		file free()
+		result
 	}
 }
 ImageFileTest new() run()


### PR DESCRIPTION
Fixes https://github.com/cogneco/ooc-kean/issues/450
Corrected conversion function in RasterYuvSemiplanar, if source height was even, this function could write outside the result buffer.
Simplified conversion function in RasterBgra.
Fixes some minor memory leaks related to not `free`d closures.
Cleaned up `ImageFileTest`, added `expect` calls to test if the image file was created.
Added `free` calls on images in `ImageFileTest`, as on Linux there was a crash in `RasterYuvSemiplanar` destructor when image height was not even (this thing crashed sooner on Windows).