### PR TITLE
Removed destroy() method from WaitCondition

### DIFF
--- a/source/sdk/threading/Thread.ooc
+++ b/source/sdk/threading/Thread.ooc
@@ -309,6 +309,4 @@ WaitCondition: abstract class {
     signal: abstract func -> Bool
 
     broadcast: abstract func -> Bool
-    
-    destroy: abstract func -> Bool
 }

--- a/source/sdk/threading/native/ConditionUnix.ooc
+++ b/source/sdk/threading/native/ConditionUnix.ooc
@@ -24,14 +24,13 @@ ConditionUnix: class extends WaitCondition {
     	raise("Something went wrong when calling pthread_cond_init")
   }
   free: override func {
-    this destroy()
+    pthread_cond_destroy(this _backend)
     gc_free(this _backend)
     super()
   }
   wait: func (mutex: Mutex) -> Bool { pthread_cond_wait(this _backend, mutex as PThreadMutex*) == 0 }
   signal: func -> Bool { pthread_cond_signal(this _backend) == 0 }
   broadcast: func -> Bool { pthread_cond_broadcast(this _backend) == 0 }
-  destroy: func -> Bool { pthread_cond_destroy(this _backend) == 0 }
 }
 
 }


### PR DESCRIPTION
Partially fixes https://github.com/cogneco/ooc-kean/issues/459
I want to keep all the pull requests for https://github.com/cogneco/ooc-kean/issues/459 small, so here goes first part.