### PR TITLE
Missing math tests

### DIFF
--- a/source/math/FloatPoint2D.ooc
+++ b/source/math/FloatPoint2D.ooc
@@ -60,7 +60,7 @@ FloatPoint2D: cover {
 	operator <= (other: This) -> Bool { this x <= other x && this y <= other y }
 	operator >= (other: This) -> Bool { this x >= other x && this y >= other y }
 	polar: static func (radius, azimuth: Float) -> This { This new(radius * cos(azimuth), radius * sin(azimuth)) }
-	toIntPoint2D: func -> IntPoint2D { IntPoint2D new(this x floor() as Int, this y floor() as Int) }
+	toIntPoint2D: func -> IntPoint2D { IntPoint2D new(this x as Int, this y as Int) }
 	toFloatSize2D: func -> FloatSize2D { FloatSize2D new(this x, this y) }
 	operator as -> String { this toString() }
 	toString: func -> String { this x toString() & ", " clone() & this y toString() }

--- a/source/math/FloatPoint3D.ooc
+++ b/source/math/FloatPoint3D.ooc
@@ -15,6 +15,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 import math
 import FloatPoint2D
+import IntPoint3D
 import text/StringTokenizer
 import structs/ArrayList
 
@@ -67,6 +68,7 @@ FloatPoint3D: cover {
 	operator > (other: This) -> Bool { this x > other x && this y > other y && this z > other z }
 	operator <= (other: This) -> Bool { this x <= other x && this y <= other y && this z <= other z }
 	operator >= (other: This) -> Bool { this x >= other x && this y >= other y && this z >= other z }
+	toIntPoint3D: func -> IntPoint3D { IntPoint3D new(this x floor() as Int, this y floor() as Int, this z floor() as Int) }
 	operator as -> String { this toString() }
 	toString: func -> String { "%.8f" formatFloat(this x) >> ", " & "%.8f" formatFloat(this y) >> ", " & "%.8f" formatFloat(this z) }
 	parse: static func (input: String) -> This {

--- a/source/math/FloatPoint3D.ooc
+++ b/source/math/FloatPoint3D.ooc
@@ -68,7 +68,7 @@ FloatPoint3D: cover {
 	operator > (other: This) -> Bool { this x > other x && this y > other y && this z > other z }
 	operator <= (other: This) -> Bool { this x <= other x && this y <= other y && this z <= other z }
 	operator >= (other: This) -> Bool { this x >= other x && this y >= other y && this z >= other z }
-	toIntPoint3D: func -> IntPoint3D { IntPoint3D new(this x floor() as Int, this y floor() as Int, this z floor() as Int) }
+	toIntPoint3D: func -> IntPoint3D { IntPoint3D new(this x as Int, this y as Int, this z as Int) }
 	operator as -> String { this toString() }
 	toString: func -> String { "%.8f" formatFloat(this x) >> ", " & "%.8f" formatFloat(this y) >> ", " & "%.8f" formatFloat(this z) }
 	parse: static func (input: String) -> This {

--- a/source/math/FloatSize3D.ooc
+++ b/source/math/FloatSize3D.ooc
@@ -15,6 +15,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 import math
 import FloatPoint3D
+import IntPoint3D
+import IntSize3D
 import text/StringTokenizer
 import structs/ArrayList
 
@@ -70,6 +72,8 @@ FloatSize3D: cover {
 	operator > (other: This) -> Bool { this width > other width && this height > other height && this depth > other depth }
 	operator <= (other: This) -> Bool { this width <= other width && this height <= other height && this depth <= other depth }
 	operator >= (other: This) -> Bool { this width >= other width && this height >= other height && this depth >= other depth }
+	toIntSize3D: func -> IntSize3D { IntSize3D new(this width as Int, this height as Int, this depth as Int) }
+	toFloatPoint3D: func -> FloatPoint3D { FloatPoint3D new(this width, this height, this depth) }
 	operator as -> String { this toString() }
 	toString: func -> String { "#{this width toString()}, #{this height toString()}, #{this depth toString()}" }
 	parse: static func (input: String) -> This {

--- a/source/math/IntPoint3D.ooc
+++ b/source/math/IntPoint3D.ooc
@@ -16,6 +16,7 @@
 import math
 import IntSize3D
 import IntPoint2D
+import FloatPoint3D
 import text/StringTokenizer
 import structs/ArrayList
 
@@ -45,6 +46,7 @@ IntPoint3D: cover {
 	operator > (other: This) -> Bool { this x > other x && this y > other y && this z > other z }
 	operator <= (other: This) -> Bool { this x <= other x && this y <= other y && this z <= other z }
 	operator >= (other: This) -> Bool { this x >= other x && this y >= other y && this z >= other z }
+	toFloatPoint3D: func -> FloatPoint3D { FloatPoint3D new(this x as Float, this y as Float, this z as Float) }
 	operator as -> String { this toString() }
 	toString: func -> String { "#{this x toString()}, #{this y toString()}, #{this z toString()}" }
 	parse: static func (input: String) -> This {

--- a/source/math/IntSize3D.ooc
+++ b/source/math/IntSize3D.ooc
@@ -29,6 +29,7 @@ IntSize3D: cover {
 	init: func@ (=width, =height, =depth)
 	init: func@ ~default { this init(0, 0, 0) }
 	scalarProduct: func (other: This) -> Int { this width * other width + this height * other height + this depth * other depth }
+	swap: func -> This { This new(this height, this width, this depth) }
 	minimum: func (ceiling: This) -> This { This new(Int minimum~two(this width, ceiling width), Int minimum~two(this height, ceiling height), Int minimum~two(this depth, ceiling depth)) }
 	maximum: func (floor: This) -> This { This new(Int maximum~two(this width, floor width), Int maximum~two(this height, floor height), Int maximum~two(this depth, floor depth)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this width clamp(floor width, ceiling width), this height clamp(floor height, ceiling height), this depth clamp(floor depth, ceiling depth)) }

--- a/source/math/IntSize3D.ooc
+++ b/source/math/IntSize3D.ooc
@@ -29,7 +29,6 @@ IntSize3D: cover {
 	init: func@ (=width, =height, =depth)
 	init: func@ ~default { this init(0, 0, 0) }
 	scalarProduct: func (other: This) -> Int { this width * other width + this height * other height + this depth * other depth }
-	swap: func -> This { This new(this height, this width, this depth) }
 	minimum: func (ceiling: This) -> This { This new(Int minimum~two(this width, ceiling width), Int minimum~two(this height, ceiling height), Int minimum~two(this depth, ceiling depth)) }
 	maximum: func (floor: This) -> This { This new(Int maximum~two(this width, floor width), Int maximum~two(this height, floor height), Int maximum~two(this depth, floor depth)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this width clamp(floor width, ceiling width), this height clamp(floor height, ceiling height), this depth clamp(floor depth, ceiling depth)) }

--- a/test/math/FloatPoint2DTest.ooc
+++ b/test/math/FloatPoint2DTest.ooc
@@ -5,53 +5,53 @@ import lang/IO
 
 FloatPoint2DTest: class extends Fixture {
 	precision := 1.0e-5f
-	vector0 := FloatPoint2D new (22.221f, -3.1f)
-	vector1 := FloatPoint2D new (12.221f, 13.1f)
-	vector2 := FloatPoint2D new (34.442f, 10.0f)
-	vector3 := FloatPoint2D new (10.0f, 20.0f)
+	point0 := FloatPoint2D new (22.221f, -3.1f)
+	point1 := FloatPoint2D new (12.221f, 13.1f)
+	point2 := FloatPoint2D new (34.442f, 10.0f)
+	point3 := FloatPoint2D new (10.0f, 20.0f)
 	init: func {
 		super("FloatPoint2D")
 		this add("equality", func {
 			point := FloatPoint2D new()
-//			expect(this vector0, is equal to(this vector0))
-//			expect(this vector0 equals(this vector0 as Object), is true)
-			expect(this vector0 == this vector0, is true)
-			expect(this vector0 != this vector1, is true)
-			expect(this vector0 == point, is false)
+//			expect(this point0, is equal to(this point0))
+//			expect(this point0 equals(this point0 as Object), is true)
+			expect(this point0 == this point0, is true)
+			expect(this point0 != this point1, is true)
+			expect(this point0 == point, is false)
 			expect(point == point, is true)
-			expect(point == this vector0, is false)
+			expect(point == this point0, is false)
 		})
 		this add("addition", func {
-			expect((this vector0 + this vector1) x, is equal to(this vector2 x))
-			expect((this vector0 + this vector1) y, is equal to(this vector2 y))
+			expect((this point0 + this point1) x, is equal to(this point2 x))
+			expect((this point0 + this point1) y, is equal to(this point2 y))
 		})
 		this add("subtraction", func {
-			expect((this vector0 - this vector0) x, is equal to((FloatPoint2D new()) x))
-			expect((this vector0 - this vector0) y, is equal to((FloatPoint2D new()) y))
+			expect((this point0 - this point0) x, is equal to((FloatPoint2D new()) x))
+			expect((this point0 - this point0) y, is equal to((FloatPoint2D new()) y))
 		})
 		this add("scalar multiplication", func {
-			expect(((-1) * this vector0) x, is equal to((-vector0) x))
-			expect(((-1) * this vector0) y, is equal to((-vector0) y))
+			expect(((-1) * this point0) x, is equal to((-point0) x))
+			expect(((-1) * this point0) y, is equal to((-point0) y))
 		})
 		this add("scalar division", func {
-			expect((this vector0 / (-1)) x, is equal to((-vector0) x))
-			expect((this vector0 / (-1)) y, is equal to((-vector0) y))
+			expect((this point0 / (-1)) x, is equal to((-point0) x))
+			expect((this point0 / (-1)) y, is equal to((-point0) y))
 		})
 		this add("get values", func {
-			expect(this vector0 x, is equal to(22.221f))
-			expect(this vector0 y, is equal to(-3.1f))
+			expect(this point0 x, is equal to(22.221f))
+			expect(this point0 y, is equal to(-3.1f))
 		})
 		this add("swap", func {
-			result := this vector0 swap()
-			expect(result x, is equal to(this vector0 y))
-			expect(result y, is equal to(this vector0 x))
+			result := this point0 swap()
+			expect(result x, is equal to(this point0 y))
+			expect(result y, is equal to(this point0 x))
 		})
 		this add("casting", func {
 			value := "10.00, 20.00"
-			expect(this vector3 toString(), is equal to(value))
+			expect(this point3 toString(), is equal to(value))
 //			FIXME: Equals interface
-			expect((FloatPoint2D parse(value)) x, is equal to((this vector3) x))
-			expect((FloatPoint2D parse(value)) y, is equal to((this vector3) y))
+			expect((FloatPoint2D parse(value)) x, is equal to((this point3) x))
+			expect((FloatPoint2D parse(value)) y, is equal to((this point3) y))
 		})
 		this add("polar 0", func {
 			point := FloatPoint2D new()
@@ -90,15 +90,17 @@ FloatPoint2DTest: class extends Fixture {
 			expect(FloatPoint2D basisX angle(-FloatPoint2D basisY), is equal to(-PI as Float / 2.0f) within(this precision))
 		})
 		this add("minimum", func {
-			expect((this vector0 minimum(this vector1)) x, is equal to((this vector1) x))
-			expect((this vector0 minimum(this vector1)) y, is equal to((this vector0) y))
+			expect((this point0 minimum(this point1)) x, is equal to((this point1) x))
+			expect((this point0 minimum(this point1)) y, is equal to((this point0) y))
 		})
 		this add("maximum", func {
-			expect((this vector0 maximum(this vector1)) x, is equal to((this vector0) x))
-			expect((this vector0 maximum(this vector1)) y, is equal to((this vector1) y))
+			expect((this point0 maximum(this point1)) x, is equal to((this point0) x))
+			expect((this point0 maximum(this point1)) y, is equal to((this point1) y))
 		})
-		this add("casts", func {
-//			FIXME: We have no integer versions of anything yet
+		this add("int casts", func {
+			point := point3 toIntPoint2D()
+			expect(point x, is equal to(10))
+			expect(point y, is equal to(20))
 		})
 	}
 }

--- a/test/math/FloatPoint3DTest.ooc
+++ b/test/math/FloatPoint3DTest.ooc
@@ -8,7 +8,7 @@ FloatPoint3DTest: class extends Fixture {
 	point0 := FloatPoint3D new (22.0f, -3.0f, 10.0f)
 	point1 := FloatPoint3D new (12.0f, 13.0f, 20.0f)
 	point2 := FloatPoint3D new (34.0f, 10.0f, 30.0f)
-	point3 := FloatPoint3D new (10.0f, 20.0f, 30.0f)
+	point3 := FloatPoint3D new (10.1f, 20.2f, 30.3f)
 	init: func {
 		super("FloatPoint3D")
 		this add("norm", func {
@@ -52,13 +52,16 @@ FloatPoint3DTest: class extends Fixture {
 			expect(this point0 z, is equal to(10.0f))
 		})
 		this add("casting", func {
-			value := "10.00000000, 20.00000000, 30.00000000"
-			expect(this point3 toString(), is equal to(value))
+			value := "12.00000000, 13.00000000, 20.00000000"
+			expect(this point1 toString(), is equal to(value))
 //			FIXME: Equals interface
 //			expect(FloatSize2D parse(value), is equal to(this vector3))
 		})
-		this add("casts", func {
-//			FIXME: We have no integer versions of anything yet
+		this add("int casts", func {
+			point := point3 toIntPoint3D()
+			expect(point x, is equal to(10))
+			expect(point y, is equal to(20))
+			expect(point z, is equal to(30))
 		})
 	}
 }

--- a/test/math/FloatSize2DTest.ooc
+++ b/test/math/FloatSize2DTest.ooc
@@ -89,8 +89,10 @@ FloatSize2DTest: class extends Fixture {
 			expect(FloatSize2D basisX angle(-FloatSize2D basisX), is equal to(PI as Float) within(this precision))
 			expect(FloatSize2D basisX angle(-FloatSize2D basisY), is equal to(-PI as Float / 2.0f) within(this precision))
 		})
-		this add("casts", func {
-//			FIXME: We have no integer versions of anything yet
+		this add("int casts", func {
+			vector := vector0 toIntSize2D()
+			expect(vector width, is equal to(22))
+			expect(vector height, is equal to(-3))
 		})
 	}
 }

--- a/test/math/FloatSize3DTest.ooc
+++ b/test/math/FloatSize3DTest.ooc
@@ -62,8 +62,11 @@ FloatSize3DTest: class extends Fixture {
 //			FIXME: Equals interface
 //			expect(FloatSize2D parse(value), is equal to(this vector3))
 		})
-		this add("casts", func {
-//			FIXME: We have no integer versions of anything yet
+		this add("int casts", func {
+			vector := vector0 toIntSize3D()
+			expect(vector width, is equal to(22))
+			expect(vector height, is equal to(-3))
+			expect(vector depth, is equal to(10))
 		})
 	}
 }

--- a/test/math/IntPoint2DTest.ooc
+++ b/test/math/IntPoint2DTest.ooc
@@ -4,47 +4,50 @@ import math
 import lang/IO
 
 IntPoint2DTest: class extends Fixture {
-	vector0 := IntPoint2D new (22, -3)
-	vector1 := IntPoint2D new (12, 13)
-	vector2 := IntPoint2D new (34, 10)
-	vector3 := IntPoint2D new (10, 20)
+	precision := 1.0e-5f
+	point0 := IntPoint2D new (22, -3)
+	point1 := IntPoint2D new (12, 13)
+	point2 := IntPoint2D new (34, 10)
+	point3 := IntPoint2D new (10, 20)
 	init: func {
 		super("IntPoint2D")
 		this add("equality", func {
 			point := IntPoint2D new()
-//			expect(this vector0, is equal to(this vector0))
-//			expect(this vector0 equals(this vector0 as Object), is true)
-			expect(this vector0 == this vector0, is true)
-			expect(this vector0 != this vector1, is true)
-			expect(this vector0 == point, is false)
+//			expect(this point0, is equal to(this point0))
+//			expect(this point0 equals(this point0 as Object), is true)
+			expect(this point0 == this point0, is true)
+			expect(this point0 != this point1, is true)
+			expect(this point0 == point, is false)
 			expect(point == point, is true)
-			expect(point == this vector0, is false)
+			expect(point == this point0, is false)
 		})
 		this add("addition", func {
-			expect((this vector0 + this vector1) x, is equal to(this vector2 x))
-			expect((this vector0 + this vector1) y, is equal to(this vector2 y))
+			expect((this point0 + this point1) x, is equal to(this point2 x))
+			expect((this point0 + this point1) y, is equal to(this point2 y))
 		})
 		this add("subtraction", func {
-			expect((this vector0 - this vector0) x, is equal to((IntPoint2D new()) x))
-			expect((this vector0 - this vector0) y, is equal to((IntPoint2D new()) y))
+			expect((this point0 - this point0) x, is equal to((IntPoint2D new()) x))
+			expect((this point0 - this point0) y, is equal to((IntPoint2D new()) y))
 		})
 		this add("get values", func {
-			expect(this vector0 x, is equal to(22))
-			expect(this vector0 y, is equal to(-3))
+			expect(this point0 x, is equal to(22))
+			expect(this point0 y, is equal to(-3))
 		})
 		this add("swap", func {
-			result := this vector0 swap()
-			expect(result x, is equal to(this vector0 y))
-			expect(result y, is equal to(this vector0 x))
+			result := this point0 swap()
+			expect(result x, is equal to(this point0 y))
+			expect(result y, is equal to(this point0 x))
 		})
 		this add("casting", func {
 			value := "10, 20"
-			expect(this vector3 toString(), is equal to(value))
+			expect(this point3 toString(), is equal to(value))
 //			FIXME: Equals interface
-//			expect(FloatSize2D parse(value), is equal to(this vector3))
+//			expect(FloatSize2D parse(value), is equal to(this point3))
 		})
-		this add("casts", func {
-//			FIXME: We have no integer versions of anything yet
+		this add("float casts", func {
+			point := point0 toFloatPoint2D()
+			expect(point x, is equal to(22.0f) within(this precision))
+			expect(point y, is equal to(-3.0f) within(this precision))
 		})
 	}
 }

--- a/test/math/IntPoint3DTest.ooc
+++ b/test/math/IntPoint3DTest.ooc
@@ -1,0 +1,65 @@
+use ooc-unit
+use ooc-math
+import math
+import lang/IO
+
+IntPoint3DTest: class extends Fixture {
+	precision := 1.0e-5f
+	point0 := IntPoint3D new (22, -3, 8)
+	point1 := IntPoint3D new (12, 13, -8)
+	point2 := IntPoint3D new (34, 10, 0)
+	point3 := IntPoint3D new (10, 20, 0)
+	init: func {
+		super("IntPoint3D")
+		this add("equality", func {
+			point := IntPoint3D new()
+//			FIXME: There is no equals interface yet
+//			expect(this point0, is equal to(this point0))
+//			expect(this point0 equals(this point0 as Object), is true)
+			expect(this point0 == this point0, is true)
+			expect(this point0 != this point1, is true)
+			expect(this point0 == point, is false)
+			expect(point == point, is true)
+			expect(point == this point0, is false)
+		})
+		this add("addition", func {
+			expect((this point0 + this point1) x, is equal to(this point2 x))
+			expect((this point0 + this point1) y, is equal to(this point2 y))
+			expect((this point0 + this point1) z, is equal to(this point2 z))
+		})
+		this add("subtraction", func {
+			expect((this point0 - this point0) x, is equal to((IntPoint3D new()) x))
+			expect((this point0 - this point0) y, is equal to((IntPoint3D new()) y))
+			expect((this point0 - this point0) z, is equal to((IntPoint3D new()) z))
+		})
+		this add("scalar multiplication", func {
+			expect(((-1) * this point0) x, is equal to((-point0) x))
+			expect(((-1) * this point0) y, is equal to((-point0) y))
+			expect(((-1) * this point0) z, is equal to((-point0) z))
+		})
+		this add("scalar division", func {
+			expect((this point0 / (-1)) x, is equal to((-point0) x))
+			expect((this point0 / (-1)) y, is equal to((-point0) y))
+			expect((this point0 / (-1)) z, is equal to((-point0) z))
+		})
+		this add("get values", func {
+			expect(this point0 x, is equal to(22))
+			expect(this point0 y, is equal to(-3))
+			expect(this point0 z, is equal to(8))
+		})
+		this add("casting", func {
+			value := "10, 20, 0"
+			expect(this point3 toString(), is equal to(value))
+//			FIXME: Equals interface
+//			expect(IntSize2D parse(value), is equal to(this point3))
+		})
+		this add("float casts", func {
+			point := point0 toFloatPoint3D()
+			expect(point x, is equal to(22.0f) within(this precision))
+			expect(point y, is equal to(-3.0f) within(this precision))
+			expect(point z, is equal to(8.0f) within(this precision))
+		})
+	}
+}
+
+IntPoint3DTest new() run()

--- a/test/math/IntSize3DTest.ooc
+++ b/test/math/IntSize3DTest.ooc
@@ -47,12 +47,6 @@ IntSize3DTest: class extends Fixture {
 			expect(this vector0 height, is equal to(-3))
 			expect(this vector0 depth, is equal to(8))
 		})
-		this add("swap", func {
-			result := this vector0 swap()
-			expect(result width, is equal to(this vector0 height))
-			expect(result height, is equal to(this vector0 width))
-			expect(result depth, is equal to(this vector0 depth))
-		})
 		this add("casting", func {
 			value := "10, 20, 0"
 			expect(this vector3 toString(), is equal to(value))

--- a/test/math/IntSize3DTest.ooc
+++ b/test/math/IntSize3DTest.ooc
@@ -3,16 +3,16 @@ use ooc-math
 import math
 import lang/IO
 
-IntSize2DTest: class extends Fixture {
+IntSize3DTest: class extends Fixture {
 	precision := 1.0e-5f
-	vector0 := IntSize2D new (22, -3)
-	vector1 := IntSize2D new (12, 13)
-	vector2 := IntSize2D new (34, 10)
-	vector3 := IntSize2D new (10, 20)
+	vector0 := IntSize3D new (22, -3, 8)
+	vector1 := IntSize3D new (12, 13, -8)
+	vector2 := IntSize3D new (34, 10, 0)
+	vector3 := IntSize3D new (10, 20, 0)
 	init: func {
-		super("IntSize2D")
+		super("IntSize3D")
 		this add("equality", func {
-			point := IntSize2D new()
+			point := IntSize3D new()
 //			FIXME: There is no equals interface yet
 //			expect(this vector0, is equal to(this vector0))
 //			expect(this vector0 equals(this vector0 as Object), is true)
@@ -25,39 +25,47 @@ IntSize2DTest: class extends Fixture {
 		this add("addition", func {
 			expect((this vector0 + this vector1) width, is equal to(this vector2 width))
 			expect((this vector0 + this vector1) height, is equal to(this vector2 height))
+			expect((this vector0 + this vector1) depth, is equal to(this vector2 depth))
 		})
 		this add("subtraction", func {
-			expect((this vector0 - this vector0) width, is equal to((IntSize2D new()) width))
-			expect((this vector0 - this vector0) height, is equal to((IntSize2D new()) height))
+			expect((this vector0 - this vector0) width, is equal to((IntSize3D new()) width))
+			expect((this vector0 - this vector0) height, is equal to((IntSize3D new()) height))
+			expect((this vector0 - this vector0) depth, is equal to((IntSize3D new()) depth))
 		})
 		this add("scalar multiplication", func {
 			expect(((-1) * this vector0) width, is equal to((-vector0) width))
 			expect(((-1) * this vector0) height, is equal to((-vector0) height))
+			expect(((-1) * this vector0) depth, is equal to((-vector0) depth))
 		})
 		this add("scalar division", func {
 			expect((this vector0 / (-1)) width, is equal to((-vector0) width))
 			expect((this vector0 / (-1)) height, is equal to((-vector0) height))
+			expect((this vector0 / (-1)) depth, is equal to((-vector0) depth))
 		})
 		this add("get values", func {
 			expect(this vector0 width, is equal to(22))
 			expect(this vector0 height, is equal to(-3))
+			expect(this vector0 depth, is equal to(8))
 		})
 		this add("swap", func {
 			result := this vector0 swap()
 			expect(result width, is equal to(this vector0 height))
 			expect(result height, is equal to(this vector0 width))
+			expect(result depth, is equal to(this vector0 depth))
 		})
 		this add("casting", func {
-			value := "10, 20"
+			value := "10, 20, 0"
 			expect(this vector3 toString(), is equal to(value))
 //			FIXME: Equals interface
 //			expect(IntSize2D parse(value), is equal to(this vector3))
 		})
 		this add("float casts", func {
-			vector := vector0 toFloatSize2D()
+			vector := vector0 toFloatSize3D()
 			expect(vector width, is equal to(22.0f) within(this precision))
 			expect(vector height, is equal to(-3.0f) within(this precision))
+			expect(vector depth, is equal to(8.0f) within(this precision))
 		})
 	}
 }
-IntSize2DTest new() run()
+
+IntSize3DTest new() run()


### PR DESCRIPTION
There were no tests for `IntPoint3D` or `IntSize3D`. Also fixed the "casts" part of many math tests and added casting functions such as `ToFloatPoint3D` wherever missing.