### PR TITLE
Fixed test script to suppress error message.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -35,7 +35,7 @@ do
 	fi
 done
 echo "Main: ./test/Tests.ooc" >> "$TESTS_USE_FILE"
-rm .libs/tests-linux64.*
+rm -f .libs/tests-linux64.*
 rock -q -lpthread --gc=off $ARGS $FLAGS $TESTS_USE_FILE 2>&1
 ./Tests
 if [[ !( $? == 0 ) ]]


### PR DESCRIPTION
Previously, if the test script tried to remove cache files that does not exist, we got an error message. I added the ```-f``` flag to the command to suppress it.