### PR TITLE
AbstractContext as parent for GpuContext

### DIFF
--- a/ooc-draw.use
+++ b/ooc-draw.use
@@ -4,6 +4,7 @@ SourcePath: source/draw
 Requires: ooc-unit
 Requires: ooc-math
 Requires: ooc-base
+Imports: AbstractContext
 Imports: Color
 Imports: Image
 Imports: RasterBgr

--- a/source/draw/AbstractContext.ooc
+++ b/source/draw/AbstractContext.ooc
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2011-2014 Simon Mika <simon@mika.se>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+use ooc-base
+use ooc-draw
+use ooc-math
+
+AlignWidth: enum {
+	Nearest
+	Floor
+	Ceiling
+}
+
+AbstractContext: abstract class {
+	init: func
+	createMonochrome: abstract func (size: IntSize2D) -> Image
+	createBgr: abstract func (size: IntSize2D) -> Image
+	createBgra: abstract func (size: IntSize2D) -> Image
+	createUv: abstract func (size: IntSize2D) -> Image
+	createGpuImage: abstract func (rasterImage: RasterImage) -> Image
+	createYuv420Semiplanar: abstract func (size: IntSize2D) -> Image
+	createYuv420Semiplanar: abstract func ~fromImages (y, uv: Image) -> Image
+	createYuv420Semiplanar: abstract func ~fromRaster (raster: RasterYuv420Semiplanar) -> Image
+	alignWidth: virtual func (width: Int, align := AlignWidth Nearest) -> Int { width }
+	update: abstract func
+	isAligned: virtual func (width: Int) -> Bool { true }
+}

--- a/source/draw/gpu/GpuContext.ooc
+++ b/source/draw/gpu/GpuContext.ooc
@@ -17,15 +17,10 @@ use ooc-math
 use ooc-draw
 use ooc-base
 use ooc-collections
+import AbstractContext
 import GpuImage, GpuSurface, GpuMap, GpuFence, GpuYuv420Semiplanar, GpuMesh
 
-AlignWidth: enum {
-	Nearest
-	Floor
-	Ceiling
-}
-
-GpuContext: abstract class {
+GpuContext: abstract class extends AbstractContext {
 	defaultMap: GpuMap { get { null } }
 	init: func
 	createMonochrome: abstract func (size: IntSize2D) -> GpuImage
@@ -40,8 +35,6 @@ GpuContext: abstract class {
 	createMesh: abstract func (vertices: FloatPoint3D[], textureCoordinates: FloatPoint2D[]) -> GpuMesh
 
 	update: abstract func
-	alignWidth: virtual func (width: Int, align := AlignWidth Nearest) -> Int { width }
-	isAligned: virtual func (width: Int) -> Bool { true }
 	packToRgba: abstract func (source: GpuImage, target: GpuImage, viewport: IntBox2D)
 	finish: func { this createFence() sync() . wait() . free() }
 

--- a/source/draw/gpu/opengl/GraphicBuffer.ooc
+++ b/source/draw/gpu/opengl/GraphicBuffer.ooc
@@ -15,6 +15,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 use ooc-math
 use ooc-base
+use ooc-draw
 use ooc-draw-gpu
 import math
 

--- a/test/draw/gpu/GraphicBufferAlignTest.ooc
+++ b/test/draw/gpu/GraphicBufferAlignTest.ooc
@@ -1,5 +1,6 @@
 use ooc-math
 use ooc-unit
+use ooc-draw
 use ooc-draw-gpu
 use ooc-base
 use ooc-opengl


### PR DESCRIPTION
Problem with this one is that I want to keep as much compatibility with existing code base in the other project as possible. There are `context createGpuImage` calls spread out in there everywhere. I know it looks weird to have `createGPUIImage` in `AbstractContext`, but I think it is wise to do that in small steps, and not try to change everything in one pull request. So for now we could just keep the API compatible.