### PR TITLE
Painter and PaintEngine implementation

### DIFF
--- a/ooc-draw-gpu.use
+++ b/ooc-draw-gpu.use
@@ -12,5 +12,6 @@ Imports: GpuMap
 Imports: GpuContext
 Imports: GpuFence
 Imports: GpuMesh
+Imports: GpuPaintEngine
 Libs: -lEGL
 Libs: -lGLESv2

--- a/ooc-draw.use
+++ b/ooc-draw.use
@@ -8,6 +8,9 @@ Imports: AbstractContext
 Imports: CpuContext
 Imports: Color
 Imports: Image
+Imports: Painter
+Imports: PaintEngine
+Imports: RasterPaintEngine
 Imports: RasterBgr
 Imports: RasterBgra
 Imports: RasterUv

--- a/source/draw/Image.ooc
+++ b/source/draw/Image.ooc
@@ -17,6 +17,7 @@
 use ooc-math
 use ooc-base
 import math
+import PaintEngine
 
 CoordinateSystem: enum {
 	Default = 0x00,
@@ -74,4 +75,5 @@ Image: abstract class {
 	isValidIn: func (x, y: Int) -> Bool {
 		return (x >= 0 && x < this size width && y >= 0 && y < this size height)
 	}
+	createPaintEngine: virtual func -> PaintEngine { null }
 }

--- a/source/draw/PaintEngine.ooc
+++ b/source/draw/PaintEngine.ooc
@@ -1,0 +1,100 @@
+//
+// Copyright (c) 2011-2014 Simon Mika <simon@mika.se>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use ooc-base
+use ooc-collections
+use ooc-math
+import math
+import Color
+
+Pen: cover {
+	color: ColorBgra { get set }
+	alpha ::= this color alpha
+	alphaAsFloat ::= this alpha as Float / 255.0f
+	init: func@ (=color)
+	init: func@ ~withBgr (colorBgr: ColorBgr) {
+		this color = colorBgr toBgra()
+	}
+	setApha: func@ (alpha: UInt8) {
+		this color = ColorBgra new(this color toBgr(), alpha)
+	}
+	setAlpha: func@ ~withFloat (value: Float) {
+		this color = ColorBgra new(this color toBgr(), value * 255)
+	}
+}
+
+PaintEngine: abstract class {
+	pen: Pen { get set }
+	init: func {
+		this pen = Pen new(ColorBgra new(255, 255, 255, 255))
+	}
+	drawPoint: abstract func (x, y: Int)
+	drawPoint: virtual func ~withIntPoint2D (position: IntPoint2D) {
+		this drawPoint(position x, position y)
+	}
+	drawPoint: virtual func ~withFloat (x, y: Float) {
+		this drawPoint(x as Int, y as Int)
+	}
+	drawPoint: virtual func ~withFloatPoint2D (position: FloatPoint2D) {
+		this drawPoint(position toIntPoint2D())
+	}
+	drawLine: virtual func (start, end: IntPoint2D) {
+		if (start y == end y) {
+			startX := Int minimum~two(start x, end x)
+			endX := Int maximum~two(start x, end x)
+			for (x in startX .. endX + 1)
+				this drawPoint(x, start y)
+		} else if (start x == end x) {
+			startY := Int minimum~two(start y, end y)
+			endY := Int maximum~two(start y, end y)
+			for (y in startY .. endY + 1)
+				this drawPoint(start x, y)
+		} else {
+			originalPen := this pen
+			originalAlpha := originalPen alphaAsFloat
+			slope := (end y - start y) as Float / (end x - start x) as Float
+			startX := Int minimum~two(start x, end x)
+			endX := Int maximum~two(start x, end x)
+			for (x in startX .. endX + 1) {
+				idealY := slope * (x - start x) + start y
+				floor := idealY floor()
+				weight := (idealY - floor) abs()
+				this pen setAlpha(originalAlpha * (1.0f - weight))
+				this drawPoint(x, floor)
+				this pen setAlpha(originalAlpha * weight)
+				this drawPoint(x, floor + 1)
+			}
+			this pen = originalPen
+		}
+	}
+	drawLine: virtual func ~withFloatPoint2D (start, end: FloatPoint2D) {
+		this drawLine(start toIntPoint2D(), end toIntPoint2D())
+	}
+	drawLines: virtual func (lines: VectorList<FloatPoint2D>) {
+		if (lines count > 1)
+			for (i in 0 .. lines count - 1)
+				this drawLine(lines[i], lines[i + 1])
+	}
+	drawBox: virtual func (box: IntBox2D) {
+		this drawLine(box leftTop, box rightTop)
+		this drawLine(box rightTop, box rightBottom)
+		this drawLine(box rightBottom, box leftBottom)
+		this drawLine(box leftBottom, box leftTop)
+	}
+	drawBox: virtual func ~withFloatBox2D (box: FloatBox2D) {
+		this drawBox(box toIntBox2D())
+	}
+}

--- a/source/draw/Painter.ooc
+++ b/source/draw/Painter.ooc
@@ -1,0 +1,83 @@
+//
+// Copyright (c) 2011-2014 Simon Mika <simon@mika.se>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use ooc-base
+use ooc-collections
+use ooc-math
+import PaintEngine
+import Image
+
+/*
+ this class uses the "Reference" coordinate system
+ origin (0,0) is in the middle of the image
+*/
+Painter: class {
+	_backend: PaintEngine
+	init: func
+	init: func ~withImage (image: Image) {
+		this paintOn(image)
+	}
+	free: override func {
+		if (this _backend)
+			this _backend free()
+		super()
+	}
+	paintOn: func (image: Image) {
+		if (this _backend)
+			this _backend free()
+		this _backend = image createPaintEngine()
+		version(safe) {
+			if (this _backend == null)
+				raise("Paint engine not implemented for " + image class name)
+		}
+	}
+	drawPoint: func (x, y: Int) {
+		this _backend drawPoint(x, y)
+	}
+	drawPoint: func ~withIntPoint2D (position: IntPoint2D) {
+		this _backend drawPoint(position)
+	}
+	drawLine: func (start, end: IntPoint2D) {
+		this _backend drawLine(start, end)
+	}
+	drawLine: func ~withCoordinates (x1, y1, x2, y2: Int) {
+		this _backend drawLine(IntPoint2D new(x1, y1), IntPoint2D new(x2, y2))
+	}
+	drawBox: func (box: IntBox2D) {
+		this _backend drawBox(box)
+	}
+	drawPoint: func ~withFloat (x, y: Float) {
+		this _backend drawPoint(x, y)
+	}
+	drawPoint: func ~withFloatPoint2D (position: FloatPoint2D) {
+		this _backend drawPoint(position)
+	}
+	drawLine: func ~withFloatPoint2D (start, end: FloatPoint2D) {
+		this _backend drawLine(start, end)
+	}
+	drawLine: func ~withFloatCoordinates (x1, y1, x2, y2: Float) {
+		this _backend drawLine(FloatPoint2D new(x1, y1), FloatPoint2D new(x2, y2))
+	}
+	drawLines: func (lines: VectorList<FloatPoint2D>) {
+		this _backend drawLines(lines)
+	}
+	drawBox: func ~withFloatBox2D (box: FloatBox2D) {
+		this _backend drawBox(box)
+	}
+	setPen: func (pen: Pen) {
+		this _backend pen = pen
+	}
+}

--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -22,6 +22,8 @@ import RasterImage
 import StbImage
 import Image
 import Color
+import PaintEngine
+import RasterPaintEngine
 
 RasterBgr: class extends RasterPacked {
 	bytesPerPixel: Int { get { 3 } }
@@ -140,4 +142,5 @@ RasterBgr: class extends RasterPacked {
 	}
 	operator [] (x, y: Int) -> ColorBgr { this isValidIn(x, y) ? ((this buffer pointer + y * this stride) as ColorBgr* + x)@ : ColorBgr new(0, 0, 0) }
 	operator []= (x, y: Int, value: ColorBgr) { ((this buffer pointer + y * this stride) as ColorBgr* + x)@ = value }
+	createPaintEngine: override func -> PaintEngine { BgrPaintEngine new(this) }
 }

--- a/source/draw/RasterBgra.ooc
+++ b/source/draw/RasterBgra.ooc
@@ -22,6 +22,8 @@ import RasterImage
 import StbImage
 import Image
 import Color
+import PaintEngine
+import RasterPaintEngine
 
 RasterBgra: class extends RasterPacked {
 	bytesPerPixel: Int { get { 4 } }
@@ -169,4 +171,5 @@ RasterBgra: class extends RasterPacked {
 			(top * (left * topLeft alpha + (1 - left) * topRight alpha) + (1 - top) * (left * bottomLeft alpha + (1 - left) * bottomRight alpha))
 		)
 	}
+	createPaintEngine: override func -> PaintEngine { BgraPaintEngine new(this) }
 }

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -22,6 +22,8 @@ import RasterImage
 import StbImage
 import Image, FloatImage
 import Color
+import PaintEngine
+import RasterPaintEngine
 
 RasterMonochrome: class extends RasterPacked {
 	bytesPerPixel: Int { get { 1 } }
@@ -241,4 +243,5 @@ RasterMonochrome: class extends RasterPacked {
 		for (row in 0 .. this size height)
 			vector add(this buffer pointer[row * this stride + column] as Float)
 	}
+	createPaintEngine: override func -> PaintEngine { MonochromePaintEngine new(this) }
 }

--- a/source/draw/RasterPaintEngine.ooc
+++ b/source/draw/RasterPaintEngine.ooc
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2011-2014 Simon Mika <simon@mika.se>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use ooc-base
+use ooc-math
+import Color, RasterBgr, RasterBgra, RasterMonochrome, RasterYuv420Semiplanar, Image
+import PaintEngine
+
+RasterPaintEngine: abstract class extends PaintEngine {
+	_imageSize: IntSize2D
+	init: func (=_imageSize) { super() }
+	_map: func (point: IntPoint2D) -> IntPoint2D {
+		IntPoint2D new(point x + this _imageSize width / 2, point y + this _imageSize height / 2)
+	}
+}
+
+MonochromePaintEngine: class extends RasterPaintEngine {
+	_image: RasterMonochrome
+	init: func (=_image) { super(this _image size) }
+	drawPoint: func (x, y: Int) {
+		position := this _map(IntPoint2D new(x, y))
+		if (this _image isValidIn(position x, position y))
+			this _image[position x, position y] = this _image[position x, position y] blend(this pen alphaAsFloat, this pen color toMonochrome())
+	}
+}
+
+BgrPaintEngine: class extends RasterPaintEngine {
+	_image: RasterBgr
+	init: func (=_image) { super(this _image size) }
+	drawPoint: func (x, y: Int) {
+		position := this _map(IntPoint2D new(x, y))
+		if (this _image isValidIn(position x, position y))
+			this _image[position x, position y] = this _image[position x, position y] blend(this pen alphaAsFloat, this pen color toBgr())
+	}
+}
+
+BgraPaintEngine: class extends RasterPaintEngine {
+	_image: RasterBgra
+	init: func (=_image) { super(this _image size) }
+	drawPoint: func (x, y: Int) {
+		position := this _map(IntPoint2D new(x, y))
+		if (this _image isValidIn(position x, position y))
+			this _image[position x, position y] = this _image[position x, position y] blend(this pen alphaAsFloat, this pen color toBgra())
+	}
+}
+
+Yuv420PaintEngine: class extends RasterPaintEngine {
+	_image: RasterYuv420Semiplanar
+	init: func (=_image) { super(this _image size) }
+	drawPoint: func (x, y: Int) {
+		position := this _map(IntPoint2D new(x, y))
+		if (this _image isValidIn(position x, position y))
+			this _image[position x, position y] = this _image[position x, position y] blend(this pen alphaAsFloat, this pen color toYuv())
+	}
+}

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -26,6 +26,8 @@ import RasterUv
 import Image
 import Color
 import RasterBgr
+import PaintEngine
+import RasterPaintEngine
 import StbImage
 import io/File
 import io/FileReader
@@ -249,4 +251,5 @@ RasterYuv420Semiplanar: class extends RasterYuvSemiplanar {
 		fileWriter write(this uv buffer pointer as Char*, this uv buffer size)
 		fileWriter close()
 	}
+	createPaintEngine: override func -> PaintEngine { Yuv420PaintEngine new(this) }
 }

--- a/source/draw/gpu/GpuPaintEngine.ooc
+++ b/source/draw/gpu/GpuPaintEngine.ooc
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2011-2014 Simon Mika <simon@mika.se>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use ooc-base
+use ooc-math
+use ooc-collections
+import PaintEngine
+import GpuImage, GpuCanvas
+
+GpuPaintEngine: class extends PaintEngine {
+	_image: GpuImage
+	init: func (=_image) { super() }
+	drawPoint: override func (x, y: Int) {
+		this drawPoint~withFloat(x, y)
+	}
+	drawPoint: override func ~withFloat (x, y: Float) {
+		vector := VectorList<FloatPoint2D> new().add(FloatPoint2D new(x, y))
+		this _image canvas drawPoints(vector)
+		vector free()
+	}
+	drawPoint: virtual func ~withFloatPoint2D (position: FloatPoint2D) {
+		this drawPoint~withFloat(position x, position y)
+	}
+	drawLine: override func ~withFloatPoint2D (start, end: FloatPoint2D) {
+		line := VectorList<FloatPoint2D> new().add(start).add(end)
+		this _image canvas drawLines(line)
+		line free()
+	}
+	drawLines: override func (lines: VectorList<FloatPoint2D>) {
+		this _image canvas drawLines(lines)
+	}
+	drawBox: override func ~withFloatBox2D (box: FloatBox2D) {
+		this _image canvas drawBox(box)
+	}
+}

--- a/source/draw/gpu/GpuYuv420Semiplanar.ooc
+++ b/source/draw/gpu/GpuYuv420Semiplanar.ooc
@@ -16,7 +16,7 @@
 
 use ooc-math
 use ooc-draw
-import GpuContext, GpuImage, GpuSurface, GpuCanvas
+import GpuContext, GpuImage, GpuSurface, GpuCanvas, GpuPaintEngine
 
 GpuYuv420Semiplanar: class extends GpuImage {
 	_y: GpuImage
@@ -69,4 +69,5 @@ GpuYuv420Semiplanar: class extends GpuImage {
 		this _y bind(unit)
 		this _uv bind(unit + 1)
 	}
+	createPaintEngine: override func -> PaintEngine { GpuPaintEngine new(this) }
 }

--- a/test/draw/PainterTest.ooc
+++ b/test/draw/PainterTest.ooc
@@ -1,0 +1,139 @@
+use ooc-unit
+use ooc-math
+use ooc-draw
+use ooc-draw-gpu
+use ooc-opengl
+
+PainterTest: class extends Fixture {
+	init: func {
+		super("Painter")
+		this add("rgb", func {
+			input := "test/draw/input/Flower.png"
+			output := "test/draw/output/painter_rasterRgb.png"
+			image := RasterBgr open(input)
+			painter := Painter new(image)
+			painter setPen(Pen new(ColorBgr new(0, 255, 0)))
+			halfWidth := image size width / 2
+			halfHeight := image size height / 2
+			painter drawLine(-halfWidth, -halfHeight, halfWidth, halfHeight)
+			painter drawLine(halfWidth, -halfHeight, -halfWidth, halfHeight)
+			image save(output)
+			original := RasterBgr open(input)
+			expect(original distance(image) > 0.0f)
+			original free()
+			painter free()
+			image free()
+			input free()
+			output free()
+		})
+		this add("rgba", func {
+			input := "test/draw/input/Flower.png"
+			output := "test/draw/output/painter_rasterRgba.png"
+			image := RasterBgra open(input)
+			painter := Painter new(image)
+			painter setPen(Pen new(ColorBgr new(128, 0, 128)))
+			for (row in 0 .. image size height / 3)
+				for (column in 0 .. image size width / 3)
+					painter drawPoint(column * 3 - image size width / 2, row * 3 - image size height / 2)
+			image save(output)
+			original := RasterBgra open(input)
+			expect(original distance(image) > 0.0f)
+			original free()
+			painter free()
+			image free()
+			input free()
+			output free()
+		})
+		this add("yuv420", func {
+			input := "test/draw/input/Flower.png"
+			output := "test/draw/output/painter_rasterYuv420.png"
+			image := RasterYuv420Semiplanar open(input)
+			painter := Painter new(image)
+			for (i in 0 .. 30) {
+				painter setPen(Pen new(ColorBgr new((i % 10) * 25, (i % 5) * 50, (i % 3) * 80)))
+				painter drawBox(IntBox2D createAround(IntPoint2D new(0, 0), IntSize2D new(10 * i, 10 * i)))
+			}
+			image save(output)
+			original := RasterYuv420Semiplanar open(input)
+			expect(original distance(image) > 0.0f)
+			original free()
+			painter free()
+			image free()
+			input free()
+			output free()
+		})
+		this add("monochrome", func {
+			input := "test/draw/input/Flower.png"
+			output := "test/draw/output/painter_rasterMonochrome.png"
+			image := RasterMonochrome open(input)
+			painter := Painter new(image)
+			painter setPen(Pen new(ColorBgr new(255, 255, 255)))
+			shiftX := image size width / 2
+			shiftY := image size height / 2
+			for (i in 0 .. image size width / 10)
+				painter drawLine(IntPoint2D new(i * 10 - shiftX, -shiftY), IntPoint2D new(i * 10 - shiftX, shiftY))
+			for (i in 0 .. image size height / 10)
+				painter drawLine(IntPoint2D new(-shiftX, i * 10 - shiftY), IntPoint2D new(shiftX, i * 10 - shiftY))
+			image save(output)
+			original := RasterMonochrome open(input)
+			expect(original distance(image) > 0.0f)
+			original free()
+			painter free()
+			image free()
+			input free()
+			output free()
+		})
+		this add("monochrome with alpha", func {
+			input := "test/draw/input/Flower.png"
+			output := "test/draw/output/painter_rasterMonochromeWithAlpha.png"
+			image := RasterMonochrome open(input)
+			painter := Painter new(image)
+			painter setPen(Pen new(ColorBgra new(255, 255, 255, 100)))
+			shiftX := image size width / 2
+			shiftY := image size height / 2
+			factor := 2
+			for (i in 0 .. image size width / factor)
+				painter drawLine(IntPoint2D new(i * factor - shiftX, -shiftY), IntPoint2D new(i * factor - shiftX, shiftY))
+			for (i in 0 .. image size height / factor)
+				painter drawLine(IntPoint2D new(-shiftX, i * factor - shiftY), IntPoint2D new(shiftX, i * factor - shiftY))
+			image save(output)
+			original := RasterMonochrome open(input)
+			expect(original distance(image) > 0.0f)
+			original free()
+			painter free()
+			image free()
+			input free()
+			output free()
+		})
+		this add("gpu", func {
+			input := "test/draw/input/Flower.png"
+			output := "test/draw/output/painter_gpuYuv.png"
+			image := RasterYuv420Semiplanar open(input)
+			context := OpenGLContext new()
+			gpuImage := context createGpuImage(image)
+			painter := Painter new(gpuImage)
+			painter setPen(Pen new(ColorBgr new(255, 255, 255)))
+			shiftX := image size width / 2
+			shiftY := image size height / 2
+			for (i in 0 .. image size width / 10)
+				painter drawLine(IntPoint2D new(i * 10 - shiftX, -shiftY), IntPoint2D new(i * 10 - shiftX, shiftY))
+			for (i in 0 .. image size height / 10)
+				painter drawLine(IntPoint2D new(-shiftX, i * 10 - shiftY), IntPoint2D new(shiftX, i * 10 - shiftY))
+			rasterImage := gpuImage toRasterAsync()
+			rasterImage save(output)
+			original := RasterYuv420Semiplanar open(output)
+			expect(original distance(rasterImage) > 0.0f)
+			original free()
+			painter free()
+			rasterImage free()
+			image free()
+			input free()
+			output free()
+			context free()
+		})
+	}
+}
+
+test := PainterTest new()
+test run()
+test free()


### PR DESCRIPTION
This pull request introduces the `Painter` class and `PaintEngine` hierarchy of classes.
`Painter` uses the `PaintEngine` as a backend to render primitives on images.
Each image subclass is responsible for creating a `PaintEngine` implementation suitable for the image type. It is enough to provide implementation for `drawPoint` for new `PaintEngine` type, drawing lines and boxes is based on that method.
As this is the first version, only basic primitives are supported, and only basic anti-aliasing is implemented. This can be extended later on by introducing a `RenderHint` flags for the paint engines and providing better painting algorithms if needed. Basic cover for `Pen` type is created and meant to be extended later (with line width, line styles, maybe a brush to fill entire shapes with colour etc.).
This version will be enough for our current needs in the *other project*, I will open a pull request there soon. 