### PR TITLE
CreateAlphaByteString now produces magic-compliant output

### DIFF
--- a/.magicignore
+++ b/.magicignore
@@ -2,3 +2,4 @@
 .libs
 rock_tmp
 source/sdk
+test/draw/output

--- a/.magicignore
+++ b/.magicignore
@@ -2,4 +2,3 @@
 .libs
 rock_tmp
 source/sdk
-test/draw/output

--- a/source/draw/CreateAlphaByteString.ooc
+++ b/source/draw/CreateAlphaByteString.ooc
@@ -34,14 +34,15 @@ CreateAlphaByteString: class {
 		}
 		ip = ipbuffer pointer as Int*
 		for (i in 0 .. ipbuffer size / 4) {
-			imageArray = imageArray + ip[i] toString() + ", "
+			imageArray = imageArray + ip[i] toString() + ","
 			counter += 1
-			if (i % 32 == 0) {
+			if (i % 32 == 0)
 				imageArray = imageArray + "\n"
-			}
+			else
+				imageArray = imageArray + " "
 		}
 		imageArray = imageArray + "]"
-		result := name + "Image" + ": StaticOverlayImages \n" + name + "Image image = " + imageArray + "\n"
+		result := name + "Image" + ": StaticOverlayImages\n" + name + "Image image = " + imageArray + "\n"
 		result = result + name + "Image size = IntSize2D new(" + image size width toString() + ", " + image size height toString() + ")\n"
 		result
 	}


### PR DESCRIPTION
Since there is a "malformed" ooc-file there.