### PR TITLE
Added setSeed and global seeds for random generators

### DIFF
--- a/source/math/FloatRandomGenerator.ooc
+++ b/source/math/FloatRandomGenerator.ooc
@@ -30,7 +30,6 @@ FloatRandomGenerator: abstract class {
 FloatUniformRandomGenerator: class extends FloatRandomGenerator {
 	_state: UInt
 	_min, _max, _rangeCoefficient: Float
-	_unsignedIntMaxAsFloat : static Float = 4294967295U as Float
 	minimum ::= this _min
 	maximum ::= this _max
 	init: func (seed := Time microtime()) {
@@ -42,7 +41,7 @@ FloatUniformRandomGenerator: class extends FloatRandomGenerator {
 		this setRange(min, max)
 	}
 	setRange: func (=_min, =_max) {
-		this _rangeCoefficient = (1.0f / This _unsignedIntMaxAsFloat) * (this _max - this _min)
+		this _rangeCoefficient = (1.0f / UINT_MAX as Float) * (this _max - this _min)
 	}
 	setSeed: func (=_state)
 	next: func -> Float {

--- a/source/math/FloatRandomGenerator.ooc
+++ b/source/math/FloatRandomGenerator.ooc
@@ -32,11 +32,11 @@ FloatUniformRandomGenerator: class extends FloatRandomGenerator {
 	_min, _max, _rangeCoefficient: Float
 	minimum ::= this _min
 	maximum ::= this _max
-	init: func (seed := Time microtime()) {
+	init: func (seed: UInt = Time microtime() as UInt) {
 		this _state = This permanentSeed != 0 ? This permanentSeed : seed
 		this setRange(0.0f, 1.0f)
 	}
-	init: func ~withParameters (min, max: Float, seed := Time microtime()) {
+	init: func ~withParameters (min, max: Float, seed: UInt = Time microtime() as UInt) {
 		this _state = This permanentSeed != 0 ? This permanentSeed : seed
 		this setRange(min, max)
 	}
@@ -62,10 +62,10 @@ FloatGaussianRandomGenerator: class extends FloatRandomGenerator {
 	init: func {
 		this _backend = FloatUniformRandomGenerator new(Float minimumValue, 1.0f)
 	}
-	init: func ~withSeed (seed: Int) {
+	init: func ~withSeed (seed: UInt) {
 		this _backend = FloatUniformRandomGenerator new(Float minimumValue, 1.0f, seed)
 	}
-	init: func ~withParameters (=_mu, =_sigma, seed := Time microtime()) {
+	init: func ~withParameters (=_mu, =_sigma, seed: UInt = Time microtime() as UInt) {
 		this _backend = FloatUniformRandomGenerator new(Float minimumValue, 1.0f, seed)
 	}
 	init: func ~withBackend (=_backend)

--- a/source/math/FloatRandomGenerator.ooc
+++ b/source/math/FloatRandomGenerator.ooc
@@ -33,11 +33,11 @@ FloatUniformRandomGenerator: class extends FloatRandomGenerator {
 	minimum ::= this _min
 	maximum ::= this _max
 	init: func (seed := Time microtime()) {
-		this _state = FloatRandomGenerator permanentSeed != 0 ? This permanentSeed : seed
+		this _state = This permanentSeed != 0 ? This permanentSeed : seed
 		this setRange(0.0f, 1.0f)
 	}
 	init: func ~withParameters (min, max: Float, seed := Time microtime()) {
-		this _state = FloatRandomGenerator permanentSeed != 0 ? This permanentSeed : seed
+		this _state = This permanentSeed != 0 ? This permanentSeed : seed
 		this setRange(min, max)
 	}
 	setRange: func (=_min, =_max) {

--- a/source/math/IntRandomGenerator.ooc
+++ b/source/math/IntRandomGenerator.ooc
@@ -72,10 +72,10 @@ IntGaussianRandomGenerator: class extends IntRandomGenerator {
 	init: func {
 		this _backend = FloatGaussianRandomGenerator new(0.0f, 1.0f)
 	}
-	init: func ~withSeed (seed: Int) {
+	init: func ~withSeed (seed: UInt) {
 		this _backend = FloatGaussianRandomGenerator new(0.0f, 1.0f, seed)
 	}
-	init: func ~withParameters (mu, sigma: Float, seed := Time microtime()) {
+	init: func ~withParameters (mu, sigma: Float, seed: UInt = Time microtime() as UInt) {
 		this _backend = FloatGaussianRandomGenerator new(mu, sigma, seed)
 	}
 	init: func ~withUniformBackend (=_backend)

--- a/source/math/IntRandomGenerator.ooc
+++ b/source/math/IntRandomGenerator.ooc
@@ -36,11 +36,11 @@ IntUniformRandomGenerator: class extends IntRandomGenerator {
 	maximum ::= this _max
 	init: func (seed := Time microtime()) {
 		this setRange(0, Int maximumValue)
-		this _state = IntRandomGenerator permanentSeed != 0 ? This permanentSeed : seed
+		this _state = This permanentSeed != 0 ? This permanentSeed : seed
 	}
 	init: func ~withParameters (min, max: Int, seed := Time microtime()) {
 		this setRange(min, max)
-		this _state = IntRandomGenerator permanentSeed != 0 ? This permanentSeed : seed
+		this _state = This permanentSeed != 0 ? This permanentSeed : seed
 	}
 	_generate: func -> Int {
 		// Based on Intel fast_rand()

--- a/source/math/IntRandomGenerator.ooc
+++ b/source/math/IntRandomGenerator.ooc
@@ -35,12 +35,12 @@ IntUniformRandomGenerator: class extends IntRandomGenerator {
 	minimum ::= this _min
 	maximum ::= this _max
 	init: func (seed := Time microtime()) {
-		this setRange(0, Int maximumValue)
 		this _state = This permanentSeed != 0 ? This permanentSeed : seed
+		this setRange(0, Int maximumValue)
 	}
 	init: func ~withParameters (min, max: Int, seed := Time microtime()) {
-		this setRange(min, max)
 		this _state = This permanentSeed != 0 ? This permanentSeed : seed
+		this setRange(min, max)
 	}
 	_generate: func -> Int {
 		// Based on Intel fast_rand()

--- a/test/math/FloatRandomGeneratorTest.ooc
+++ b/test/math/FloatRandomGeneratorTest.ooc
@@ -100,6 +100,24 @@ FloatRandomGeneratorTest: class extends Fixture {
 			expect(Float absolute(mean - expectedMean) < tolerance)
 			expect(Float absolute(deviation - expectedDeviation) < tolerance)
 		})
+		this add("set seed", func {
+			generator1 := FloatUniformRandomGenerator new(0, 100)
+			generator1 setSeed(123456)
+			expect(generator1 next(), is equal to(5.99f) within(0.01f))
+			expect(generator1 next(), is equal to(54.54f) within(0.01f))
+			expect(generator1 next(), is equal to(20.76f) within(0.01f))
+		})
+		this add("global seed", func {
+			FloatRandomGenerator permanentSeed = 123455
+			generator1 := FloatUniformRandomGenerator new(0, 100)
+			expect(generator1 next(), is equal to(5.98f) within(0.01f))
+			expect(generator1 next(), is equal to(57.96f) within(0.01f))
+			expect(generator1 next(), is equal to(8.52f) within(0.01f))
+			generator2 := FloatUniformRandomGenerator new(0, 100)
+			expect(generator2 next(), is equal to(5.98f) within(0.01f))
+			expect(generator2 next(), is equal to(57.96f) within(0.01f))
+			expect(generator2 next(), is equal to(8.52f) within(0.01f))
+		})
 	}
 }
 FloatRandomGeneratorTest new() run()

--- a/test/math/IntRandomGeneratorTest.ooc
+++ b/test/math/IntRandomGeneratorTest.ooc
@@ -51,6 +51,24 @@ IntRandomGeneratorTest: class extends Fixture {
 			expect(Int absolute(mean - expectedMean) < 2)
 			expect(Int absolute(deviation - expectedDeviation) < 2)
 		})
+		this add("set seed", func {
+			generator1 := IntUniformRandomGenerator new(0, 100)
+			generator1 setSeed(123456)
+			expect(generator1 next(), is equal to(79))
+			expect(generator1 next(), is equal to(93))
+			expect(generator1 next(), is equal to(50))
+		})
+		this add("global seed", func {
+			IntRandomGenerator permanentSeed = 123455
+			generator1 := IntUniformRandomGenerator new(0, 100)
+			expect(generator1 next(), is equal to(76))
+			expect(generator1 next(), is equal to(51))
+			expect(generator1 next(), is equal to(6))
+			generator2 := IntUniformRandomGenerator new(0, 100)
+			expect(generator2 next(), is equal to(76))
+			expect(generator2 next(), is equal to(51))
+			expect(generator2 next(), is equal to(6))
+		})
 	}
 }
 


### PR DESCRIPTION
Adds `permanentSeed` for Int and Float random generators. If they are non-zero will override the seed automatically generated from `Time microtime()`. Useful for debug purposes.
Also adds the somehow missing `setSeed(Int)` which was missing - if you only want to control a single generator instance.