### PR TITLE
Method to swap red and blue channels in rgb and rgba images

### DIFF
--- a/source/draw/Image.ooc
+++ b/source/draw/Image.ooc
@@ -30,6 +30,8 @@ CoordinateSystem: enum {
 Image: abstract class {
 	_size: IntSize2D
 	size ::= this _size
+	width ::= this size width
+	height ::= this size height
 	transform: IntTransform2D { get set }
 	coordinateSystem: CoordinateSystem {
 		get

--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -142,5 +142,13 @@ RasterBgr: class extends RasterPacked {
 	}
 	operator [] (x, y: Int) -> ColorBgr { this isValidIn(x, y) ? ((this buffer pointer + y * this stride) as ColorBgr* + x)@ : ColorBgr new(0, 0, 0) }
 	operator []= (x, y: Int, value: ColorBgr) { ((this buffer pointer + y * this stride) as ColorBgr* + x)@ = value }
+	swapRedBlue: func {
+		this swapChannels(0, 2)
+	}
+	redBlueSwapped: func -> This {
+		result := this copy()
+		result swapRedBlue()
+		result
+	}
 	createPaintEngine: override func -> PaintEngine { BgrPaintEngine new(this) }
 }

--- a/source/draw/RasterBgra.ooc
+++ b/source/draw/RasterBgra.ooc
@@ -171,5 +171,13 @@ RasterBgra: class extends RasterPacked {
 			(top * (left * topLeft alpha + (1 - left) * topRight alpha) + (1 - top) * (left * bottomLeft alpha + (1 - left) * bottomRight alpha))
 		)
 	}
+	swapRedBlue: func {
+		this swapChannels(0, 2)
+	}
+	redBlueSwapped: func -> This {
+		result := this copy()
+		result swapRedBlue()
+		result
+	}
 	createPaintEngine: override func -> PaintEngine { BgraPaintEngine new(this) }
 }

--- a/source/draw/RasterPacked.ooc
+++ b/source/draw/RasterPacked.ooc
@@ -89,4 +89,18 @@ RasterPacked: abstract class extends RasterImage {
 		file free()
 		StbImage writePng(filename, this size width, this size height, this bytesPerPixel, this buffer pointer, this size width * this bytesPerPixel)
 	}
+	swapChannels: func (first, second: Int) {
+		version(safe) {
+			if (first > this bytesPerPixel || second > this bytesPerPixel)
+				raise("Channel number too large")
+		}
+		pointer := this buffer pointer
+		index := 0
+		while (index < this buffer size) {
+			value := pointer[index + first]
+			pointer[index + first] = pointer[index + second]
+			pointer[index + second] = value
+			index += this bytesPerPixel
+		}
+	}
 }

--- a/test/draw/RasterBgrTest.ooc
+++ b/test/draw/RasterBgrTest.ooc
@@ -45,7 +45,25 @@ RasterBgrTest: class extends Fixture {
 			expect(image2 distance(image3), is equal to(0.0f))
 			image1 free(); image2 free(); image3 free()
 		})
+		this add("swapped RB", func {
+			output := "test/draw/output/rbswapped.png"
+			image := RasterBgr open(this sourceFlower)
+			image2 := RasterBgr open(this sourceFlower)
+			image swapRedBlue()
+			image save(output)
+			for (row in 0 .. image height)
+				for (column in 0 .. image width) {
+					pixel1 := image[column, row]
+					pixel2 := image2[column, row]
+					expect(pixel1 red == pixel2 blue)
+					expect(pixel1 green == pixel2 green)
+					expect(pixel1 blue == pixel2 red)
+				}
+			image free()
+			image2 free()
+			output free()
+		})
 	}
 }
 
-RasterBgrTest new() run()
+RasterBgrTest new() run() . free()

--- a/test/draw/RasterBgraTest.ooc
+++ b/test/draw/RasterBgraTest.ooc
@@ -45,7 +45,26 @@ RasterBgraTest: class extends Fixture {
 			expect(image2 distance(image3), is equal to(0.0f))
 			image1 free(); image2 free(); image3 free()
 		})
+		this add("swapped RB", func {
+			output := "test/draw/output/rbswapped_bgra.png"
+			image := RasterBgra open(this sourceFlower)
+			image2 := RasterBgra open(this sourceFlower)
+			image swapRedBlue()
+			image save(output)
+			for (row in 0 .. image height)
+				for (column in 0 .. image width) {
+					pixel1 := image[column, row]
+					pixel2 := image2[column, row]
+					expect(pixel1 red == pixel2 blue)
+					expect(pixel1 green == pixel2 green)
+					expect(pixel1 blue == pixel2 red)
+					expect(pixel1 alpha == pixel2 alpha)
+				}
+			image free()
+			image2 free()
+			output free()
+		})
 	}
 }
 
-RasterBgraTest new() run()
+RasterBgraTest new() run() . free()


### PR DESCRIPTION
We will need it on windows for debugging, @jonathanudd discovered that while working on the window class.
This pull request also introduces the `width` and `height` properties for `Image` class. I think it is better to write `for (row in 0 .. image height)` than `for (row in 0 .. image size height)`.