### PR TITLE
added Bool to Cell toString()

### DIFF
--- a/source/sdk/lang/types.ooc
+++ b/source/sdk/lang/types.ooc
@@ -135,6 +135,8 @@ Cell: class <T> {
 	// TODO: Move this to an extension in ooc-kean later
 	toString: func -> String {
 		match T {
+			case Bool =>
+				(this val as Bool) toString()
 			case Int =>
 				(this val as Int) toString()
 			case Long =>


### PR DESCRIPTION
This fixes any Fixture crashes where these tests fail:
```expect(someCondition, is equal to(false))```
```expect(someCondition, is equal to(true))```

Hint: For booleans, use these instead:
```expect(someCondition, is false)```
```expect(someCondition, is true)```

