### PR TITLE
Bilinear interpolation for `resize` in RasterMonochrome

### DIFF
--- a/source/draw/Image.ooc
+++ b/source/draw/Image.ooc
@@ -27,6 +27,11 @@ CoordinateSystem: enum {
 	YUpward = 0x02
 }
 
+TransformMethod: enum {
+	Fast, // nearest neighbour
+	Smooth // bilinear
+}
+
 Image: abstract class {
 	_size: IntSize2D
 	size ::= this _size
@@ -78,6 +83,9 @@ Image: abstract class {
 		this resizeTo(((this size toFloatSize2D()) * Float minimum(restriction width as Float / this size width as Float, restriction height as Float / this size height as Float)) toIntSize2D())
 	}
 	resizeTo: abstract func (size: IntSize2D) -> This
+	resizeTo: virtual func ~withMethod (size: IntSize2D, method: TransformMethod) -> This {
+		this resizeTo(size)
+	}
 	create: virtual func (size: IntSize2D) -> This { raise("Image type not implemented."); null }
 	copy: abstract func -> This
 	copy: abstract func ~fromParams (size: IntSize2D, transform: FloatTransform2D) -> This

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -58,20 +58,61 @@ RasterMonochrome: class extends RasterPacked {
 			}
 	}
 	resizeTo: override func (size: IntSize2D) -> This {
+		this resizeTo(size, TransformMethod Smooth) as This
+	}
+	resizeTo: override func ~withMethod (size: IntSize2D, method: TransformMethod) -> This {
 		result: This
 		if (this size == size)
 			result = this copy()
 		else {
 			result = This new(size)
-			for (row in 0 .. size height) {
-				srcRow := (this size height * row) / size height
-				for (column in 0 .. size width) {
-					srcColumn := (this size width * column) / size width
-					result[column, row] = this[srcColumn, srcRow]
-				}
+			match (method) {
+				case TransformMethod Smooth => This _resizeBilinear(this, result)
+				case => This _resizeNearestNeighbour(this, result)
 			}
 		}
 		result
+	}
+	_resizeNearestNeighbour: static func (source, result: This) {
+		resultBuffer := result buffer pointer
+		sourceBuffer := source buffer pointer
+		for (row in 0 .. result size height) {
+			sourceRow := (source size height * row) / result size height
+			for (column in 0 .. result size width) {
+				sourceColumn := (source size width * column) / result size width
+				resultBuffer[column + result stride * row] = sourceBuffer[sourceColumn + source stride * sourceRow]
+			}
+		}
+	}
+	_resizeBilinear: static func (source, result: This) {
+		resultBuffer := result buffer pointer
+		sourceBuffer := source buffer pointer
+		for (row in 0 .. result size height) {
+			sourceRow := ((source size height as Float) * row) / result size height
+			sourceRowUp := sourceRow floor() as Int
+			weightDown := sourceRow - sourceRowUp as Float
+			sourceRowDown := (sourceRow - weightDown) as Int + 1
+			rowDownValid := sourceRowDown < source size height
+			if (!rowDownValid)
+				weightDown = 0.0f
+			for (column in 0 .. result size width) {
+				sourceColumn := ((source size width as Float) * column) / result size width
+				sourceColumnLeft := sourceColumn floor() as Int
+				weightRight := sourceColumn - sourceColumnLeft as Float
+				sourceColumnRight := (sourceColumn - weightRight) as Int + 1
+				columnRightValid := sourceColumnRight < source size width
+				if (!columnRightValid)
+					weightRight = 0.0f
+				valueRowUp := (1.0f - weightRight) * sourceBuffer[sourceColumnLeft + sourceRowUp * source stride]
+				if (columnRightValid)
+					valueRowUp += weightRight * sourceBuffer[sourceColumnRight + sourceRowUp * source stride]
+				valueRowDown := 0.0f
+				if (rowDownValid)
+					valueRowDown += (1.0f - weightRight) * sourceBuffer[sourceColumnLeft + sourceRowDown * source stride] + (columnRightValid ? (weightRight * sourceBuffer[sourceColumnRight + sourceRowDown * source stride]) : 0.0f)
+				pixelValue := weightDown * valueRowDown + (1.0f - weightDown) * valueRowUp
+				resultBuffer[column + row * result stride] = pixelValue as UInt8
+			}
+		}
 	}
 	distance: override func (other: Image) -> Float {
 		result := 0.0f

--- a/test/draw/RasterMonochromeTest.ooc
+++ b/test/draw/RasterMonochromeTest.ooc
@@ -56,17 +56,34 @@ RasterMonochromeTest: class extends Fixture {
 				for (i in 0 .. rowData count)
 					expect(rowData[i] as UInt8 == row)
 			}
+			image free()
 		})
 		this add("resize", func {
+			outputFast := "test/draw/output/RasterMonochrome_upscaledFast.png"
+			outputSmooth := "test/draw/output/RasterMonochrome_upscaledSmooth.png"
 			size := IntSize2D new(13, 5)
 			image := RasterMonochrome open(this sourceFlower)
 			image2 := image resizeTo(image size / 2)
 			expect(image2 size == image size / 2)
-			image2 = image2 resizeTo(image size)
-			expect(image2 size == image size)
-			expect(image distance(image2) < image size width / 10)
-			image2 = image2 resizeTo(size)
-			expect(image2 size == size)
+			image3 := image2 resizeTo(image size)
+			expect(image3 size == image size)
+			expect(image distance(image3) < image size width / 10)
+			image3 referenceCount decrease()
+			image3 = image2 resizeTo(size)
+			expect(image3 size == size)
+			image3 referenceCount decrease()
+			image2 referenceCount decrease()
+			image2 = image resizeTo(image size / 4)
+			image referenceCount decrease()
+			image = image2 resizeTo(image2 size * 4, TransformMethod Fast)
+			image save(outputFast)
+			image referenceCount decrease()
+			image = image2 resizeTo(image2 size * 4, TransformMethod Smooth)
+			image save(outputSmooth)
+			image referenceCount decrease()
+			image2 referenceCount decrease()
+			outputFast free()
+			outputSmooth free()
 		})
 		this add("copy", func {
 			image := RasterMonochrome open(this sourceFlower)
@@ -89,4 +106,6 @@ RasterMonochromeTest: class extends Fixture {
 	}
 }
 
-RasterMonochromeTest new() run()
+test := RasterMonochromeTest new()
+test run()
+test free()


### PR DESCRIPTION
Introduces bilinear interpolation in `RasterMonochrome::resizeTo` method.
I want to generalize this method and introduce bilinear rescaling for each image class, hopefully without duplicating much of the code (the only difference is in the pixel type, so it should be possible to create a generic method for this).