### PR TITLE
Run kean tests on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+version: 1.0.{build}
+os: Windows Server 2012 R2
+environment:
+  PATH: C:\MinGW\bin;C:\msys64\usr\bin;%PATH%
+install:
+- cmd: >-
+    bash install_rock.sh
+
+    mv rock.exe C:\msys64\usr\bin\
+
+    mingw-get install pthreads
+build: off
+test_script:
+- cmd: bash test.sh nogpu

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: 0.1.{build}
 os: Windows Server 2012 R2
 environment:
   PATH: C:\MinGW\bin;C:\msys64\usr\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,4 +11,4 @@ install:
     mingw-get install pthreads
 build: off
 test_script:
-- cmd: bash test.sh nogpu
+- cmd: bash test.sh nogpu -DgpuOff

--- a/install_rock.sh
+++ b/install_rock.sh
@@ -8,7 +8,7 @@ else
 	tmp="$(wget -O - https://github.com/cogneco/rock/releases/latest | grep -o '\<download/rock_.*deb\>')"
 	wget https://github.com/cogneco/rock/releases/$tmp
 	echo ${tmp##*/}
-	# dpkg-deb -x ${tmp##*/} .
-	# mv usr/bin/rock .
-	# mv usr/lib/fancy_backtrace.so .
+	dpkg-deb -x ${tmp##*/} .
+	mv usr/bin/rock .
+	mv usr/lib/fancy_backtrace.so .
 fi

--- a/install_rock.sh
+++ b/install_rock.sh
@@ -1,6 +1,14 @@
-tmp="$(wget -O - https://github.com/cogneco/rock/releases/latest | grep -o '\<download/rock_.*deb\>')"
-wget https://github.com/cogneco/rock/releases/$tmp
-echo ${tmp##*/}
-dpkg-deb -x ${tmp##*/} .
-mv usr/bin/rock .
-mv usr/lib/fancy_backtrace.so .
+#!/bin/bash
+if [ "$(uname -o)" == "Msys" ]; then
+	tmp="$(wget -O - https://github.com/cogneco/rock/releases/latest | grep -o '\<download/rock_.*zip\>')"
+	wget https://github.com/cogneco/rock/releases/$tmp
+	echo ${tmp##*/}
+	7z e ${tmp##*/}
+else
+	tmp="$(wget -O - https://github.com/cogneco/rock/releases/latest | grep -o '\<download/rock_.*deb\>')"
+	wget https://github.com/cogneco/rock/releases/$tmp
+	echo ${tmp##*/}
+	# dpkg-deb -x ${tmp##*/} .
+	# mv usr/bin/rock .
+	# mv usr/lib/fancy_backtrace.so .
+fi


### PR DESCRIPTION
- The yml file for appveyor installs rock and then run the tests for kean.
It runs the tests without gpu and also with the compile flag `-DgpuOff` and for the tests to not fail PR #535 is needed because it introduced `-DgpuOff`.
- A step for installing a windows version of rock in the install_rock script is also added.