### PR TITLE
Valgrind suppression file to filter out Fixture from logs

### DIFF
--- a/kean.supp
+++ b/kean.supp
@@ -1,0 +1,18 @@
+{
+   fixture_getis
+   Memcheck:Leak
+   ...
+   fun:Fixture__Fixture___getis__
+}
+{
+   fixture_expect
+   Memcheck:Leak
+   ...
+   fun:Fixture__Fixture_expect_*
+}
+{
+   fixture_getequal
+   Memcheck:Leak
+   ...
+   fun:Constraints__IsConstraints___getequal__
+}


### PR DESCRIPTION
I use this file to suppress memory leaks from `Fixture`. I know that @thomasfanell wants to rewrite it, but maybe someone will find this file useful until then.