### PR TITLE
Abstract base class for display window

### DIFF
--- a/ooc-widgets.use
+++ b/ooc-widgets.use
@@ -1,0 +1,6 @@
+Name: ooc display widgets
+Description: Display widgets, platform independent
+SourcePath: source/widgets
+Imports: DisplayWindow
+Imports: UnixWindow
+Imports: Win32DisplayWindow

--- a/source/ui/win32/Win32Window.ooc
+++ b/source/ui/win32/Win32Window.ooc
@@ -19,6 +19,7 @@ use ooc-math
 use ooc-draw
 import include/win32
 
+version(windows){
 Win32Window: class extends NativeWindow {
 	init: func (size: IntSize2D, title: String) {
 		windowClassName := "Window class" as CString
@@ -72,4 +73,5 @@ Win32Window: class extends NativeWindow {
 		}
 		return DefWindowProc(backend, message, wParam, lParam)
 	}
+}
 }

--- a/source/ui/win32/include/win32.ooc
+++ b/source/ui/win32/include/win32.ooc
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this software. If not, see <http://www.gnu.org/licenses/>.
  */
-
+version(windows){
 include windows
 
 LPSTR: cover from Char*
@@ -98,3 +98,4 @@ BitBlt: extern func (hdcDest: HDC, nXDest, nYDest, nWidth, nHeight: Int, hdcSrc:
 DeleteDC: extern func (hdcMem: HDC) -> Bool
 EndPaint: extern func (hwnd: HWND, ps: PaintStruct*) -> Bool
 InvalidateRect: extern func (hwnd: HWND, lpRect: Rect*, bErase: Bool) -> Bool
+}

--- a/source/widgets/DisplayWindow.ooc
+++ b/source/widgets/DisplayWindow.ooc
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2014 - Simon Mika <simon@mika.se>
+ *
+ * This sofware is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use ooc-draw
+use ooc-math
+import UnixWindow
+import Win32DisplayWindow
+
+DisplayWindow: abstract class {
+	init: func (size: IntSize2D, title: String)
+	draw: abstract func (image: Image)
+	refresh: virtual func
+	create: static func (size: IntSize2D, title: String) -> This {
+		version(unix || apple)
+			return UnixWindow new(size, title)
+		version(windows)
+			return Win32DisplayWindow new(size, title)
+		raise("Platform not supported (DisplayWindow)")
+		null
+	}
+}

--- a/source/widgets/UnixWindow.ooc
+++ b/source/widgets/UnixWindow.ooc
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2014 - Simon Mika <simon@mika.se>
+ *
+ * This sofware is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import DisplayWindow
+use ooc-draw-gpu
+use ooc-math
+use ooc-draw
+use ooc-opengl
+use ooc-x11
+
+version(unix || apple) {
+UnixWindow: class extends DisplayWindow {
+	_xWindow: X11Window
+	_openGLWindow: OpenGLWindow
+	context ::= this _openGLWindow context
+	init: func (size: IntSize2D, title: String) {
+		super()
+		this _xWindow = X11Window new(size, title)
+		this _openGLWindow = OpenGLWindow new(this _xWindow)
+	}
+	free: override func {
+		this _openGLWindow free()
+		this _xWindow free()
+		super()
+	}
+	draw: override func (image: Image) {
+		this _openGLWindow draw(image as GpuImage)
+	}
+	refresh: override func {
+		this _openGLWindow refresh()
+	}
+}
+}

--- a/source/widgets/Win32DisplayWindow.ooc
+++ b/source/widgets/Win32DisplayWindow.ooc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2014 - Simon Mika <simon@mika.se>
+ *
+ * This sofware is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import DisplayWindow
+use ooc-math
+use ooc-draw
+import win32/Win32Window
+
+version(windows) {
+Win32DisplayWindow: class extends DisplayWindow {
+	_backend: Win32Window
+	init: func (size: IntSize2D, title: String) {
+		super()
+		this _backend = Win32Window new(size, title)
+	}
+	free: override func {
+		this _backend free()
+		super()
+	}
+	draw: override func (image: Image) {
+		raster := RasterBgra convertFrom(image as RasterImage)
+		this _backend draw(raster)
+		raster referenceCount decrease()
+	}
+}
+}


### PR DESCRIPTION
This PR introduces the platform-independent window base class.
It also cleans up the opengl-x11 window code management (no need to have separate `xWindow` and `openGLWindow` in the other project).

I needed to create it in separate module. I could not add this into the `ui` module, as there are dependencies between `ui` and `opengl` (opengl uses ui, so you can't use stuff from opengl in ui, and the `UnixWindow` class needs it).