### PR TITLE
More todo fixme cleanup

### DIFF
--- a/source/base/Synchronized.ooc
+++ b/source/base/Synchronized.ooc
@@ -23,7 +23,6 @@ Synchronized: class {
 		if (this _lock != null)
 			this _lock free()
 		this _lock = null
-//		this _lock free()
 		super()
 	}
 	lock: func {

--- a/source/base/Synchronized.ooc
+++ b/source/base/Synchronized.ooc
@@ -32,19 +32,11 @@ Synchronized: class {
 	unlock: func {
 		this _lock unlock()
 	}
-
 	lock: func ~action (action: Func) {
 		this lock()
-//		try {
-			action()
-			this unlock()
-//		} catch(e: Exception) {
-//			this unlock()
-//			e throw()
-//		}
-//		FIXME: What is this commented-out code doing here?
+		action()
+		this unlock()
 	}
-
 	lockFunc: func <T> (function: Func -> T) -> T {
 		result: T
 		this lock()

--- a/source/collections/Vector.ooc
+++ b/source/collections/Vector.ooc
@@ -112,15 +112,15 @@ HeapVector: class <T> extends Vector<T> {
 
 	operator [] (index: Int) -> T {
 		version (safe) {
-			if (index >= this capacity || index < 0 || index >= this capacity)
-				raise("Accessing Vector index out of range in set operator")
+			if (index >= this capacity || index < 0)
+				raise("Accessing Vector index out of range in get operator")
 		}
 		this _backend[index]
 	}
 
 	operator []= (index: Int, item: T) {
 		version (safe) {
-			if (index >= this capacity || index < 0 || index >= this capacity)
+			if (index >= this capacity || index < 0)
 				raise("Accessing Vector index out of range in set operator")
 		}
 		if (this _freeContent && T inheritsFrom?(Object)) {

--- a/source/collections/Vector.ooc
+++ b/source/collections/Vector.ooc
@@ -112,8 +112,7 @@ HeapVector: class <T> extends Vector<T> {
 
 	operator [] (index: Int) -> T {
 		version (safe) {
-			// TODO: Should we also check that index < count?
-			if (index >= this capacity || index < 0)
+			if (index >= this capacity || index < 0 || index >= this capacity)
 				raise("Accessing Vector index out of range in set operator")
 		}
 		this _backend[index]
@@ -121,9 +120,7 @@ HeapVector: class <T> extends Vector<T> {
 
 	operator []= (index: Int, item: T) {
 		version (safe) {
-			// TODO: Should we also check that index < count?
-			// TODO: Should this affect count, if index > count?
-			if (index >= this capacity || index < 0)
+			if (index >= this capacity || index < 0 || index >= this capacity)
 				raise("Accessing Vector index out of range in set operator")
 		}
 		if (this _freeContent && T inheritsFrom?(Object)) {

--- a/source/collections/VectorList.ooc
+++ b/source/collections/VectorList.ooc
@@ -82,9 +82,17 @@ VectorList: class <T> {
 		result
 	}
 	operator [] (index: Int) -> T {
+		version (safe) {
+			if (index >= this count)
+				raise("Accessing VectorList index out of range in get operator")
+		}
 		this _vector[index]
 	}
 	operator []= (index: Int, item: T) {
+		version (safe) {
+			if (index >= this count)
+				raise("Accessing VectorList index out of range in set operator")
+		}
 		this _vector[index] = item
 	}
 	sort: func (greaterThan: Func (T, T) -> Bool) {

--- a/source/draw/Image.ooc
+++ b/source/draw/Image.ooc
@@ -69,7 +69,6 @@ Image: abstract class {
 	create: virtual func (size: IntSize2D) -> This { raise("Image type not implemented."); null }
 	copy: abstract func -> This
 	copy: abstract func ~fromParams (size: IntSize2D, transform: FloatTransform2D) -> This
-//	shift: abstract func (offset: IntSize2D) -> This
 	flush: func
 	finish: func -> Bool { true }
 	distance: virtual abstract func (other: This) -> Float

--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -108,11 +108,7 @@ RasterBgr: class extends RasterPacked {
 		x, y, n: Int
 		requiredComponents := 3
 		data := StbImage load(filename, x&, y&, n&, requiredComponents)
-		result := This new(IntSize2D new(x, y))
-		memcpy(result buffer pointer, data, x * y * requiredComponents)
-		// FIXME: Find a better way to do this using Dispose() or something
-		StbImage free(data)
-		result
+		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {
 		result := This new(original size)

--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -105,9 +105,9 @@ RasterBgr: class extends RasterPacked {
 		}
 	}
 	open: static func (filename: String) -> This {
-		x, y, totalComponents: Int
+		x, y, imageComponents: Int
 		requiredComponents := 3
-		data := StbImage load(filename, x&, y&, totalComponents&, requiredComponents)
+		data := StbImage load(filename, x&, y&, imageComponents&, requiredComponents)
 		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {

--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -105,9 +105,9 @@ RasterBgr: class extends RasterPacked {
 		}
 	}
 	open: static func (filename: String) -> This {
-		x, y, n: Int
+		x, y, totalComponents: Int
 		requiredComponents := 3
-		data := StbImage load(filename, x&, y&, n&, requiredComponents)
+		data := StbImage load(filename, x&, y&, totalComponents&, requiredComponents)
 		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {

--- a/source/draw/RasterBgra.ooc
+++ b/source/draw/RasterBgra.ooc
@@ -117,11 +117,7 @@ RasterBgra: class extends RasterPacked {
 		x, y, n: Int
 		requiredComponents := 4
 		data := StbImage load(filename, x&, y&, n&, requiredComponents)
-		buffer := ByteBuffer new(x * y * requiredComponents)
-		// FIXME: Find a better way to do this using Dispose() or something
-		memcpy(buffer pointer, data, x * y * requiredComponents)
-		StbImage free(data)
-		This new(buffer, IntSize2D new(x, y))
+		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {
 		result := This new(original size)

--- a/source/draw/RasterBgra.ooc
+++ b/source/draw/RasterBgra.ooc
@@ -114,9 +114,9 @@ RasterBgra: class extends RasterPacked {
 		}
 	}
 	open: static func (filename: String) -> This {
-		x, y, n: Int
+		x, y, totalComponents: Int
 		requiredComponents := 4
-		data := StbImage load(filename, x&, y&, n&, requiredComponents)
+		data := StbImage load(filename, x&, y&, totalComponents&, requiredComponents)
 		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {

--- a/source/draw/RasterBgra.ooc
+++ b/source/draw/RasterBgra.ooc
@@ -114,9 +114,9 @@ RasterBgra: class extends RasterPacked {
 		}
 	}
 	open: static func (filename: String) -> This {
-		x, y, totalComponents: Int
+		x, y, imageComponents: Int
 		requiredComponents := 4
-		data := StbImage load(filename, x&, y&, totalComponents&, requiredComponents)
+		data := StbImage load(filename, x&, y&, imageComponents&, requiredComponents)
 		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {

--- a/source/draw/RasterImage.ooc
+++ b/source/draw/RasterImage.ooc
@@ -62,18 +62,14 @@ RasterImage: abstract class extends Image {
 	open: static func ~unknownType (filename: String) -> This {
 		x, y, n: Int
 		data := StbImage load(filename, x&, y&, n&, 0)
-		buffer := ByteBuffer new(x * y * n)
-		// FIXME: Find a better way to do this using Dispose() or something
-		memcpy(buffer pointer, data, x * y * n)
-		StbImage free(data)
 		result: This
 		match (n) {
 			case 1 =>
-				result = RasterMonochrome new(buffer, IntSize2D new (x, y))
+				result = RasterMonochrome new(ByteBuffer new(data as UInt8*, x * y * n), IntSize2D new (x, y))
 			case 3 =>
-				result = RasterBgr new(buffer, IntSize2D new (x, y))
+				result = RasterBgr new(ByteBuffer new(data as UInt8*, x * y * n), IntSize2D new (x, y))
 			case 4 =>
-				result = RasterBgra new(buffer, IntSize2D new (x, y))
+				result = RasterBgra new(ByteBuffer new(data as UInt8*, x * y * n), IntSize2D new (x, y))
 			case =>
 				raise("Unsupported number of channels in image")
 		}

--- a/source/draw/RasterImage.ooc
+++ b/source/draw/RasterImage.ooc
@@ -60,16 +60,16 @@ RasterImage: abstract class extends Image {
 		result
 	}
 	open: static func ~unknownType (filename: String) -> This {
-		x, y, n: Int
-		data := StbImage load(filename, x&, y&, n&, 0)
+		x, y, totalComponents: Int
+		data := StbImage load(filename, x&, y&, totalComponents&, 0)
 		result: This
-		match (n) {
+		match (totalComponents) {
 			case 1 =>
-				result = RasterMonochrome new(ByteBuffer new(data as UInt8*, x * y * n), IntSize2D new (x, y))
+				result = RasterMonochrome new(ByteBuffer new(data as UInt8*, x * y * totalComponents), IntSize2D new (x, y))
 			case 3 =>
-				result = RasterBgr new(ByteBuffer new(data as UInt8*, x * y * n), IntSize2D new (x, y))
+				result = RasterBgr new(ByteBuffer new(data as UInt8*, x * y * totalComponents), IntSize2D new (x, y))
 			case 4 =>
-				result = RasterBgra new(ByteBuffer new(data as UInt8*, x * y * n), IntSize2D new (x, y))
+				result = RasterBgra new(ByteBuffer new(data as UInt8*, x * y * totalComponents), IntSize2D new (x, y))
 			case =>
 				raise("Unsupported number of channels in image")
 		}

--- a/source/draw/RasterImage.ooc
+++ b/source/draw/RasterImage.ooc
@@ -60,16 +60,16 @@ RasterImage: abstract class extends Image {
 		result
 	}
 	open: static func ~unknownType (filename: String) -> This {
-		x, y, totalComponents: Int
-		data := StbImage load(filename, x&, y&, totalComponents&, 0)
+		x, y, imageComponents: Int
+		data := StbImage load(filename, x&, y&, imageComponents&, 0)
 		result: This
-		match (totalComponents) {
+		match (imageComponents) {
 			case 1 =>
-				result = RasterMonochrome new(ByteBuffer new(data as UInt8*, x * y * totalComponents), IntSize2D new (x, y))
+				result = RasterMonochrome new(ByteBuffer new(data as UInt8*, x * y * imageComponents), IntSize2D new (x, y))
 			case 3 =>
-				result = RasterBgr new(ByteBuffer new(data as UInt8*, x * y * totalComponents), IntSize2D new (x, y))
+				result = RasterBgr new(ByteBuffer new(data as UInt8*, x * y * imageComponents), IntSize2D new (x, y))
 			case 4 =>
-				result = RasterBgra new(ByteBuffer new(data as UInt8*, x * y * totalComponents), IntSize2D new (x, y))
+				result = RasterBgra new(ByteBuffer new(data as UInt8*, x * y * imageComponents), IntSize2D new (x, y))
 			case =>
 				raise("Unsupported number of channels in image")
 		}

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -106,11 +106,7 @@ RasterMonochrome: class extends RasterPacked {
 		x, y, n: Int
 		requiredComponents := 1
 		data := StbImage load(filename, x&, y&, n&, requiredComponents)
-		buffer := ByteBuffer new(x * y * requiredComponents)
-		// FIXME: Find a better way to do this using Dispose() or something
-		memcpy(buffer pointer, data, x * y * requiredComponents)
-		StbImage free(data)
-		This new(buffer, IntSize2D new(x, y))
+		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {
 		result := This new(original size)

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -103,9 +103,9 @@ RasterMonochrome: class extends RasterPacked {
 		}
 	}
 	open: static func (filename: String) -> This {
-		x, y, n: Int
+		x, y, totalComponents: Int
 		requiredComponents := 1
-		data := StbImage load(filename, x&, y&, n&, requiredComponents)
+		data := StbImage load(filename, x&, y&, totalComponents&, requiredComponents)
 		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -103,9 +103,9 @@ RasterMonochrome: class extends RasterPacked {
 		}
 	}
 	open: static func (filename: String) -> This {
-		x, y, totalComponents: Int
+		x, y, imageComponents: Int
 		requiredComponents := 1
-		data := StbImage load(filename, x&, y&, totalComponents&, requiredComponents)
+		data := StbImage load(filename, x&, y&, imageComponents&, requiredComponents)
 		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {

--- a/source/draw/RasterPacked.ooc
+++ b/source/draw/RasterPacked.ooc
@@ -53,28 +53,6 @@ RasterPacked: abstract class extends RasterImage {
 		this _buffer = null
 		super()
 	}
-	/*shift: func (offset: IntSize2D) -> Image {
-		result: RasterImage
-		if (this instanceOf?(RasterMonochrome))
-			result = RasterMonochrome new(this size)
-		else if (this instanceOf?(RasterBgr))
-			result = RasterBgr new(this size)
-		else if (this instanceOf?(RasterBgra))
-			result = RasterBgra new(this size)
-//		else if (this instanceOf?(RasterYuyv))
-//			result = RasterYuyv new(this size)
-		// FIXME: Use this line if and when Yuyv is implemented
-//		offsetX := Int modulo(this instanceOf?(RasterYuyv) && Int modulo(offset width, 2) != 0 ? offset width + 1 : offset width, this size width)
-		offsetX := Int modulo(offset width, this size width)
-		length := (this size width - offsetX) * this bytesPerPixel
-		line := this size width * this bytesPerPixel
-		for (y in 0..this size height) {
-			destination := Int modulo(y + offset height, this size height) * this stride
-			result buffer copyFrom(this buffer, this stride * y, destination + offsetX * this bytesPerPixel, length)
-			result buffer copyFrom(this buffer, this stride * y + length, destination, line - length)
-		}
-		result
-	}*/
 	equals: func (other: Image) -> Bool {
 		other instanceOf?(This) && this bytesPerPixel == (other as This) bytesPerPixel && this as Image equals(other)
 	}

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -105,10 +105,10 @@ RasterUv: class extends RasterPacked {
 		}
 	}
 	open: static func (filename: String) -> This {
-		x, y, totalComponents: Int
+		x, y, imageComponents: Int
 		requiredComponents := 3
-		data := StbImage load(filename, x&, y&, totalComponents&, requiredComponents)
-		// Is it neccessary to create a RasterBgr here?
+		data := StbImage load(filename, x&, y&, imageComponents&, requiredComponents)
+		//FIXME: Is it neccessary to create a RasterBgr here?
 		This convertFrom(RasterBgr new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y)))
 	}
 	save: override func (filename: String) -> Int {

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -108,12 +108,8 @@ RasterUv: class extends RasterPacked {
 		x, y, n: Int
 		requiredComponents := 3
 		data := StbImage load(filename, x&, y&, n&, requiredComponents)
-		buffer := ByteBuffer new(x * y * requiredComponents)
-		// FIXME: Find a better way to do this using Dispose() or something
-		memcpy(buffer pointer, data, x * y * requiredComponents)
-		StbImage free(data)
 		// Is it neccessary to create a RasterBgr here?
-		This convertFrom(RasterBgr new(buffer, IntSize2D new(x, y)))
+		This convertFrom(RasterBgr new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y)))
 	}
 	save: override func (filename: String) -> Int {
 		bgr := RasterBgr new(this buffer, this size)

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -105,9 +105,9 @@ RasterUv: class extends RasterPacked {
 		}
 	}
 	open: static func (filename: String) -> This {
-		x, y, n: Int
+		x, y, totalComponents: Int
 		requiredComponents := 3
-		data := StbImage load(filename, x&, y&, n&, requiredComponents)
+		data := StbImage load(filename, x&, y&, totalComponents&, requiredComponents)
 		// Is it neccessary to create a RasterBgr here?
 		This convertFrom(RasterBgr new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y)))
 	}

--- a/source/draw/RasterYuv422Semipacked.ooc
+++ b/source/draw/RasterYuv422Semipacked.ooc
@@ -113,9 +113,9 @@ RasterYuv422Semipacked: class extends RasterPacked {
 		}
 	}
 	open: static func (filename: String) -> This {
-		x, y, totalComponents: Int
+		x, y, imageComponents: Int
 		requiredComponents := 3
-		data := StbImage load(filename, x&, y&, totalComponents&, requiredComponents)
+		data := StbImage load(filename, x&, y&, imageComponents&, requiredComponents)
 		bgr := RasterBgr new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 		result := This new(bgr)
 		bgr referenceCount decrease()

--- a/source/draw/RasterYuv422Semipacked.ooc
+++ b/source/draw/RasterYuv422Semipacked.ooc
@@ -36,7 +36,7 @@ RasterYuv422Semipacked: class extends RasterPacked {
 	init: func ~allocate (size: IntSize2D) { super~allocate(size) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntSize2D) { super(buffer, size, this bytesPerPixel * size width) }
 	init: func ~fromRasterImage (original: RasterImage) { super(original) }
-	createFrom: func ~fromRasterImage (original: RasterImage) {
+	/*createFrom: func ~fromRasterImage (original: RasterImage) {
 		// TODO: What does this function even do?
 //		"RasterYuv420 init ~fromRasterImage, original: (#{original size}), this: (#{this size}), y stride #{this y stride}" println()
 		y := 0
@@ -64,7 +64,7 @@ RasterYuv422Semipacked: class extends RasterPacked {
 			}
 		}
 		original apply(f)
-	}
+	}*/
 	create: func (size: IntSize2D) -> Image {
 		result := This new(size)
 		result crop = this crop
@@ -113,9 +113,9 @@ RasterYuv422Semipacked: class extends RasterPacked {
 		}
 	}
 	open: static func (filename: String) -> This {
-		x, y, n: Int
+		x, y, totalComponents: Int
 		requiredComponents := 3
-		data := StbImage load(filename, x&, y&, n&, requiredComponents)
+		data := StbImage load(filename, x&, y&, totalComponents&, requiredComponents)
 		bgr := RasterBgr new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 		result := This new(bgr)
 		bgr referenceCount decrease()

--- a/source/draw/RasterYuv422Semipacked.ooc
+++ b/source/draw/RasterYuv422Semipacked.ooc
@@ -116,11 +116,7 @@ RasterYuv422Semipacked: class extends RasterPacked {
 		x, y, n: Int
 		requiredComponents := 3
 		data := StbImage load(filename, x&, y&, n&, requiredComponents)
-		buffer := ByteBuffer new(x * y * requiredComponents)
-		// FIXME: Find a better way to do this using Dispose() or something
-		memcpy(buffer pointer, data, x * y * requiredComponents)
-		StbImage free(data)
-		bgr := RasterBgr new(buffer, IntSize2D new(x, y))
+		bgr := RasterBgr new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 		result := This new(bgr)
 		bgr referenceCount decrease()
 		return result

--- a/source/draw/RasterYuv422Semipacked.ooc
+++ b/source/draw/RasterYuv422Semipacked.ooc
@@ -36,8 +36,8 @@ RasterYuv422Semipacked: class extends RasterPacked {
 	init: func ~allocate (size: IntSize2D) { super~allocate(size) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntSize2D) { super(buffer, size, this bytesPerPixel * size width) }
 	init: func ~fromRasterImage (original: RasterImage) { super(original) }
-	/*createFrom: func ~fromRasterImage (original: RasterImage) {
-		// TODO: What does this function even do?
+	createFrom: func ~fromRasterImage (original: RasterImage) {
+		// TODO: Figure out what this function does and whether to remove it
 //		"RasterYuv420 init ~fromRasterImage, original: (#{original size}), this: (#{this size}), y stride #{this y stride}" println()
 		y := 0
 		x := 0
@@ -64,7 +64,7 @@ RasterYuv422Semipacked: class extends RasterPacked {
 			}
 		}
 		original apply(f)
-	}*/
+	}
 	create: func (size: IntSize2D) -> Image {
 		result := This new(size)
 		result crop = this crop

--- a/source/draw/gpu/GpuImage.ooc
+++ b/source/draw/gpu/GpuImage.ooc
@@ -51,7 +51,6 @@ GpuImage: abstract class extends Image {
 		}
 		super()
 	}
-	//TODO: Implement abstract functions
 	resizeTo: override func (size: IntSize2D) -> This {
 		result := this create(size) as This
 		result canvas draw(this, size)

--- a/source/draw/gpu/GpuImage.ooc
+++ b/source/draw/gpu/GpuImage.ooc
@@ -59,7 +59,6 @@ GpuImage: abstract class extends Image {
 	}
 	copy: override func -> This { this resizeTo(this size) }
 	copy: func ~fromParams (size: IntSize2D, transform: FloatTransform2D) -> This { raise("Using unimplemented function copy ~fromParams in GpuImage class"); null }
-	shift: func (offset: IntSize2D) -> This { raise("Using unimplemented function shift in GpuImage class"); null }
 	distance: func (other: This) -> Float { raise("Using unimplemented function distance in GpuImage class"); 0.0f }
 
 	upload: abstract func (image: RasterImage)


### PR DESCRIPTION
Mostly changes to `open()` in `Raster*` classes. "Fixes" #561 
Removed commented-out code in `Synchronized` (we never use try-catch anywhere else, so...)
And fixed `TODO`s in `Vector`.