### PR TITLE
Removed -lpthreads flag when calling rock

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -36,7 +36,7 @@ do
 done
 echo "Main: ./test/Tests.ooc" >> "$TESTS_USE_FILE"
 rm -f .libs/tests-linux64.*
-rock -q -lpthread --gc=off $ARGS $FLAGS $TESTS_USE_FILE && ./Tests
+rock -q --gc=off $ARGS $FLAGS $TESTS_USE_FILE && ./Tests
 if [[ !( $? == 0 ) ]]
 then
 	exit 1


### PR DESCRIPTION
The flag -lpthreads was needed when compiling without gc before but now it is fixed.
See this PR fasterthanlime/rock#919