### PR TITLE
Added version blocks around EGL and OpenGL lib links in usefiles

### DIFF
--- a/ooc-draw-gpu.use
+++ b/ooc-draw-gpu.use
@@ -13,5 +13,7 @@ Imports: GpuContext
 Imports: GpuFence
 Imports: GpuMesh
 Imports: GpuPaintEngine
-Libs: -lEGL
-Libs: -lGLESv2
+version (linux || apple) {
+	Libs: -lEGL
+	Libs: -lGLESv2
+}

--- a/ooc-opengl.use
+++ b/ooc-opengl.use
@@ -22,5 +22,5 @@ Imports: AndroidContext
 Imports: EGLBgra
 Imports: GraphicBuffer
 Imports: GraphicBufferYuv420Semiplanar
-
-Libs: -lEGL
+version (linux || apple)
+	Libs: -lEGL

--- a/ooc-x11.use
+++ b/ooc-x11.use
@@ -2,5 +2,5 @@ Name: ooc X11
 Description: X11 implementations for ooc
 SourcePath: source/ui/x11
 Imports: X11Window
-version(!windows)
+version(linux)
 	Libs: -lX11


### PR DESCRIPTION
It would be more correct to use `version (!gpuOff)` but at the moment we are not able to use custom flags in version blocks in use files but we need this now when running on windows.
This should also solve the failing appveyor tests.