### PR TITLE
Added resize functions for Box that don't affect the center

### DIFF
--- a/source/math/FloatBox2D.ooc
+++ b/source/math/FloatBox2D.ooc
@@ -70,10 +70,10 @@ FloatBox2D: cover {
 		This createAround(this center, value * this size)
 	}
 	enlargeTo: func (size: FloatSize2D) -> This {
-		This createAround(this center, this size + ((size - this size) maximum~Float(0.0f)))
+		This createAround(this center, FloatSize2D maximum(this size, size))
 	}
 	shrinkTo: func (size: FloatSize2D) -> This {
-		This createAround(this center, this size + ((size - this size) minimum~Float(0.0f)))
+		This createAround(this center, FloatSize2D minimum(this size, size))
 	}
 	intersection: func (other: This) -> This {
 		left := Float maximum(this left, other left)

--- a/source/math/FloatBox2D.ooc
+++ b/source/math/FloatBox2D.ooc
@@ -66,7 +66,15 @@ FloatBox2D: cover {
 	scale: func (value: Float) -> This {
 		sizeChange := this size - (this size * value)
 		This new(this leftTop + (sizeChange / 2.0f), this size - sizeChange)
-	}	
+	}
+	enlarge: func (size: FloatSize2D) -> This {
+		sizeChange := (size - this size) maximum~Float(0.0f)
+		This new(this leftTop - (sizeChange / 2.0f), this size + sizeChange)
+	}
+	reduce: func (size: FloatSize2D) -> This {
+		sizeChange := (size - this size) minimum~Float(0.0f)
+		This new(this leftTop - (sizeChange / 2.0f), this size + sizeChange)
+	}
 	intersection: func (other: This) -> This {
 		left := Float maximum(this left, other left)
 		top := Float maximum(this top, other top)

--- a/source/math/FloatBox2D.ooc
+++ b/source/math/FloatBox2D.ooc
@@ -72,7 +72,7 @@ FloatBox2D: cover {
 	enlargeTo: func (size: FloatSize2D) -> This {
 		This createAround(this center, this size + ((size - this size) maximum~Float(0.0f)))
 	}
-	reduceTo: func (size: FloatSize2D) -> This {
+	shrinkTo: func (size: FloatSize2D) -> This {
 		This createAround(this center, this size + ((size - this size) minimum~Float(0.0f)))
 	}
 	intersection: func (other: This) -> This {

--- a/source/math/FloatBox2D.ooc
+++ b/source/math/FloatBox2D.ooc
@@ -63,7 +63,7 @@ FloatBox2D: cover {
 	shrink: func ~fraction (margin: Float) -> This {
 		this pad(-margin * this height / 2.0f)
 	}
-	setSize: func (size: FloatSize2D) -> This {
+	resizeTo: func (size: FloatSize2D) -> This {
 		This createAround(this center, size)
 	}
 	scale: func (value: Float) -> This {

--- a/source/math/FloatBox2D.ooc
+++ b/source/math/FloatBox2D.ooc
@@ -63,6 +63,10 @@ FloatBox2D: cover {
 	shrink: func ~fraction (margin: Float) -> This {
 		this pad(-margin * this height / 2.0f)
 	}
+	scale: func (value: Float) -> This {
+		sizeChange := this size - (this size * value)
+		This new(this leftTop + (sizeChange / 2.0f), this size - sizeChange)
+	}	
 	intersection: func (other: This) -> This {
 		left := Float maximum(this left, other left)
 		top := Float maximum(this top, other top)

--- a/source/math/FloatBox2D.ooc
+++ b/source/math/FloatBox2D.ooc
@@ -63,17 +63,17 @@ FloatBox2D: cover {
 	shrink: func ~fraction (margin: Float) -> This {
 		this pad(-margin * this height / 2.0f)
 	}
+	setSize: func (size: FloatSize2D) -> This {
+		This createAround(this center, size)
+	}
 	scale: func (value: Float) -> This {
-		sizeChange := this size - (this size * value)
-		This new(this leftTop + (sizeChange / 2.0f), this size - sizeChange)
+		This createAround(this center, value * this size)
 	}
-	enlarge: func (size: FloatSize2D) -> This {
-		sizeChange := (size - this size) maximum~Float(0.0f)
-		This new(this leftTop - (sizeChange / 2.0f), this size + sizeChange)
+	enlargeTo: func (size: FloatSize2D) -> This {
+		This createAround(this center, this size + ((size - this size) maximum~Float(0.0f)))
 	}
-	reduce: func (size: FloatSize2D) -> This {
-		sizeChange := (size - this size) minimum~Float(0.0f)
-		This new(this leftTop - (sizeChange / 2.0f), this size + sizeChange)
+	reduceTo: func (size: FloatSize2D) -> This {
+		This createAround(this center, this size + ((size - this size) minimum~Float(0.0f)))
 	}
 	intersection: func (other: This) -> This {
 		left := Float maximum(this left, other left)

--- a/source/math/IntBox2D.ooc
+++ b/source/math/IntBox2D.ooc
@@ -62,7 +62,15 @@ IntBox2D: cover {
 	scale: func (value: Float) -> This {
 		sizeChange := this size - (this size * value)
 		This new(this leftTop + (sizeChange / 2), this size - sizeChange)
-	}	
+	}
+	enlarge: func (size: IntSize2D) -> This {
+		sizeChange := (size - this size) maximum~Int(0)
+		This new(this leftTop - (sizeChange / 2.0f), this size + sizeChange)
+	}
+	reduce: func (size: IntSize2D) -> This {
+		sizeChange := (size - this size) minimum~Int(0)
+		This new(this leftTop - (sizeChange / 2.0f), this size + sizeChange)
+	}
 	intersection: func (other: This) -> This {
 		left := Int maximum~two(this left, other left)
 		top := Int maximum~two(this top, other top)

--- a/source/math/IntBox2D.ooc
+++ b/source/math/IntBox2D.ooc
@@ -59,6 +59,10 @@ IntBox2D: cover {
 	}
 	pad: func ~fromFloat (pad: Int) -> This { this pad(pad, pad, pad, pad) }
 	pad: func ~fromSize (pad: IntSize2D) -> This { this pad(pad width, pad width, pad height, pad height) }
+	scale: func (value: Float) -> This {
+		sizeChange := this size - (this size * value)
+		This new(this leftTop + (sizeChange / 2), this size - sizeChange)
+	}	
 	intersection: func (other: This) -> This {
 		left := Int maximum~two(this left, other left)
 		top := Int maximum~two(this top, other top)

--- a/source/math/IntBox2D.ooc
+++ b/source/math/IntBox2D.ooc
@@ -59,17 +59,17 @@ IntBox2D: cover {
 	}
 	pad: func ~fromFloat (pad: Int) -> This { this pad(pad, pad, pad, pad) }
 	pad: func ~fromSize (pad: IntSize2D) -> This { this pad(pad width, pad width, pad height, pad height) }
+	setSize: func (size: IntSize2D) -> This {
+		This createAround(this center, size)
+	}
 	scale: func (value: Float) -> This {
-		sizeChange := this size - (this size * value)
-		This new(this leftTop + (sizeChange / 2), this size - sizeChange)
+		This createAround(this center, value * this size)
 	}
-	enlarge: func (size: IntSize2D) -> This {
-		sizeChange := (size - this size) maximum~Int(0)
-		This new(this leftTop - (sizeChange / 2), this size + sizeChange)
+	enlargeTo: func (size: IntSize2D) -> This {
+		This createAround(this center, this size + ((size - this size) maximum~Int(0)))
 	}
-	reduce: func (size: IntSize2D) -> This {
-		sizeChange := (size - this size) minimum~Int(0)
-		This new(this leftTop - (sizeChange / 2), this size + sizeChange)
+	reduceTo: func (size: IntSize2D) -> This {
+		This createAround(this center, this size + ((size - this size) minimum~Int(0)))
 	}
 	intersection: func (other: This) -> This {
 		left := Int maximum~two(this left, other left)

--- a/source/math/IntBox2D.ooc
+++ b/source/math/IntBox2D.ooc
@@ -68,7 +68,7 @@ IntBox2D: cover {
 	enlargeTo: func (size: IntSize2D) -> This {
 		This createAround(this center, this size + ((size - this size) maximum~Int(0)))
 	}
-	reduceTo: func (size: IntSize2D) -> This {
+	shrinkTo: func (size: IntSize2D) -> This {
 		This createAround(this center, this size + ((size - this size) minimum~Int(0)))
 	}
 	intersection: func (other: This) -> This {

--- a/source/math/IntBox2D.ooc
+++ b/source/math/IntBox2D.ooc
@@ -59,7 +59,7 @@ IntBox2D: cover {
 	}
 	pad: func ~fromFloat (pad: Int) -> This { this pad(pad, pad, pad, pad) }
 	pad: func ~fromSize (pad: IntSize2D) -> This { this pad(pad width, pad width, pad height, pad height) }
-	setSize: func (size: IntSize2D) -> This {
+	resizeTo: func (size: IntSize2D) -> This {
 		This createAround(this center, size)
 	}
 	scale: func (value: Float) -> This {

--- a/source/math/IntBox2D.ooc
+++ b/source/math/IntBox2D.ooc
@@ -65,11 +65,11 @@ IntBox2D: cover {
 	}
 	enlarge: func (size: IntSize2D) -> This {
 		sizeChange := (size - this size) maximum~Int(0)
-		This new(this leftTop - (sizeChange / 2.0f), this size + sizeChange)
+		This new(this leftTop - (sizeChange / 2), this size + sizeChange)
 	}
 	reduce: func (size: IntSize2D) -> This {
 		sizeChange := (size - this size) minimum~Int(0)
-		This new(this leftTop - (sizeChange / 2.0f), this size + sizeChange)
+		This new(this leftTop - (sizeChange / 2), this size + sizeChange)
 	}
 	intersection: func (other: This) -> This {
 		left := Int maximum~two(this left, other left)

--- a/source/math/IntBox2D.ooc
+++ b/source/math/IntBox2D.ooc
@@ -66,10 +66,10 @@ IntBox2D: cover {
 		This createAround(this center, value * this size)
 	}
 	enlargeTo: func (size: IntSize2D) -> This {
-		This createAround(this center, this size + ((size - this size) maximum~Int(0)))
+		This createAround(this center, IntSize2D maximum(this size, size))
 	}
 	shrinkTo: func (size: IntSize2D) -> This {
-		This createAround(this center, this size + ((size - this size) minimum~Int(0)))
+		This createAround(this center, IntSize2D minimum(this size, size))
 	}
 	intersection: func (other: This) -> This {
 		left := Int maximum~two(this left, other left)

--- a/source/math/IntSize2D.ooc
+++ b/source/math/IntSize2D.ooc
@@ -33,6 +33,8 @@ IntSize2D: cover {
 	swap: func -> This { This new(this height, this width) }
 	minimum: func (ceiling: This) -> This { This new(Int minimum~two(this width, ceiling width), Int minimum~two(this height, ceiling height)) }
 	maximum: func (floor: This) -> This { This new(Int maximum~two(this width, floor width), Int maximum~two(this height, floor height)) }
+	minimum: func ~Int (ceiling: Int) -> This { this minimum(This new(ceiling)) }
+	maximum: func ~Int (floor: Int) -> This { this maximum(This new(floor)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this width clamp(floor width, ceiling width), this height clamp(floor height, ceiling height)) }
 	fillEven: static func (other: This) -> This { This new(other width + (other width % 2 == 1 ? 1 : 0), other height + (other height % 2 == 1 ? 1 : 0)) }
 	operator + (other: This) -> This { This new(this width + other width, this height + other height) }

--- a/test/math/FloatBox2DTest.ooc
+++ b/test/math/FloatBox2DTest.ooc
@@ -56,9 +56,9 @@ FloatBox2DTest: class extends Fixture {
 			shrunkBox := paddedBox shrink(1.0f / 11.0f)
 			expect(box == shrunkBox, is true)
 		})
-		this add("setSize", func {
+		this add("resizeTo", func {
 			box := FloatBox2D new(1.0f, 1.0f, 4.0f, 4.0f)
-			changedBox := box setSize(FloatSize2D new(2.0f, 2.0f))
+			changedBox := box resizeTo(FloatSize2D new(2.0f, 2.0f))
 			expect(changedBox left, is equal to(2.0f) within(this precision))
 			expect(changedBox right, is equal to(4.0f) within(this precision))
 			expect(changedBox top, is equal to(2.0f) within(this precision))

--- a/test/math/FloatBox2DTest.ooc
+++ b/test/math/FloatBox2DTest.ooc
@@ -56,6 +56,14 @@ FloatBox2DTest: class extends Fixture {
 			shrunkBox := paddedBox shrink(1.0f / 11.0f)
 			expect(box == shrunkBox, is true)
 		})
+		this add("setSize", func {
+			box := FloatBox2D new(1.0f, 1.0f, 4.0f, 4.0f)
+			changedBox := box setSize(FloatSize2D new(2.0f, 2.0f))
+			expect(changedBox left, is equal to(2.0f) within(this precision))
+			expect(changedBox right, is equal to(4.0f) within(this precision))
+			expect(changedBox top, is equal to(2.0f) within(this precision))
+			expect(changedBox bottom, is equal to(4.0f) within(this precision))
+		})
 		this add("scale", func {
 			box := FloatBox2D new(1.0f, 1.0f, 4.0f, 4.0f)
 			doubledBox := box scale(2.0f)
@@ -71,8 +79,8 @@ FloatBox2DTest: class extends Fixture {
 		})
 		this add("enlarge", func {
 			box := FloatBox2D new(1.0f, 1.0f, 4.0f, 4.0f)
-			enlargedBox := box enlarge(FloatSize2D new(6.0f, 6.0f))
-			notEnlargedBox := box enlarge(FloatSize2D new(3.0f, 3.0f))
+			enlargedBox := box enlargeTo(FloatSize2D new(6.0f, 6.0f))
+			notEnlargedBox := box enlargeTo(FloatSize2D new(3.0f, 3.0f))
 			expect(enlargedBox left, is equal to(0.0f) within(this precision))
 			expect(enlargedBox top, is equal to(0.0f) within(this precision))
 			expect(enlargedBox right, is equal to(6.0f) within(this precision))
@@ -81,8 +89,8 @@ FloatBox2DTest: class extends Fixture {
 		})
 		this add("reduce", func {
 			box := FloatBox2D new(1.0f, 1.0f, 4.0f, 4.0f)
-			reducedBox := box reduce(FloatSize2D new(2.0f, 2.0f))
-			notReducedBox := box reduce(FloatSize2D new(6.0f, 6.0f))
+			reducedBox := box reduceTo(FloatSize2D new(2.0f, 2.0f))
+			notReducedBox := box reduceTo(FloatSize2D new(6.0f, 6.0f))
 			expect(reducedBox left, is equal to(2.0f) within(this precision))
 			expect(reducedBox top, is equal to(2.0f) within(this precision))
 			expect(reducedBox right, is equal to(4.0f) within(this precision))

--- a/test/math/FloatBox2DTest.ooc
+++ b/test/math/FloatBox2DTest.ooc
@@ -89,8 +89,8 @@ FloatBox2DTest: class extends Fixture {
 		})
 		this add("reduce", func {
 			box := FloatBox2D new(1.0f, 1.0f, 4.0f, 4.0f)
-			reducedBox := box reduceTo(FloatSize2D new(2.0f, 2.0f))
-			notReducedBox := box reduceTo(FloatSize2D new(6.0f, 6.0f))
+			reducedBox := box shrinkTo(FloatSize2D new(2.0f, 2.0f))
+			notReducedBox := box shrinkTo(FloatSize2D new(6.0f, 6.0f))
 			expect(reducedBox left, is equal to(2.0f) within(this precision))
 			expect(reducedBox top, is equal to(2.0f) within(this precision))
 			expect(reducedBox right, is equal to(4.0f) within(this precision))

--- a/test/math/FloatBox2DTest.ooc
+++ b/test/math/FloatBox2DTest.ooc
@@ -69,6 +69,26 @@ FloatBox2DTest: class extends Fixture {
 			expect(halfBox top, is equal to(2.0f) within(this precision))
 			expect(halfBox bottom, is equal to(4.0f) within(this precision))
 		})
+		this add("enlarge", func {
+			box := FloatBox2D new(1.0f, 1.0f, 4.0f, 4.0f)
+			enlargedBox := box enlarge(FloatSize2D new(6.0f, 6.0f))
+			notEnlargedBox := box enlarge(FloatSize2D new(3.0f, 3.0f))
+			expect(enlargedBox left, is equal to(0.0f) within(this precision))
+			expect(enlargedBox top, is equal to(0.0f) within(this precision))
+			expect(enlargedBox right, is equal to(6.0f) within(this precision))
+			expect(enlargedBox bottom, is equal to(6.0f) within(this precision))
+			expect(notEnlargedBox == box, is true)
+		})
+		this add("reduce", func {
+			box := FloatBox2D new(1.0f, 1.0f, 4.0f, 4.0f)
+			reducedBox := box reduce(FloatSize2D new(2.0f, 2.0f))
+			notReducedBox := box reduce(FloatSize2D new(6.0f, 6.0f))
+			expect(reducedBox left, is equal to(2.0f) within(this precision))
+			expect(reducedBox top, is equal to(2.0f) within(this precision))
+			expect(reducedBox right, is equal to(4.0f) within(this precision))
+			expect(reducedBox bottom, is equal to(4.0f) within(this precision))
+			expect(notReducedBox == box, is true)
+		})
 	}
 }
 FloatBox2DTest new() run()

--- a/test/math/FloatBox2DTest.ooc
+++ b/test/math/FloatBox2DTest.ooc
@@ -56,6 +56,19 @@ FloatBox2DTest: class extends Fixture {
 			shrunkBox := paddedBox shrink(1.0f / 11.0f)
 			expect(box == shrunkBox, is true)
 		})
+		this add("scale", func {
+			box := FloatBox2D new(1.0f, 1.0f, 4.0f, 4.0f)
+			doubledBox := box scale(2.0f)
+			halfBox := box scale(0.5f)
+			expect(doubledBox left, is equal to(-1.0f) within(this precision))
+			expect(doubledBox right, is equal to(7.0f) within(this precision))
+			expect(doubledBox top, is equal to(-1.0f) within(this precision))
+			expect(doubledBox bottom, is equal to(7.0f) within(this precision))
+			expect(halfBox left, is equal to(2.0f) within(this precision))
+			expect(halfBox right, is equal to(4.0f) within(this precision))
+			expect(halfBox top, is equal to(2.0f) within(this precision))
+			expect(halfBox bottom, is equal to(4.0f) within(this precision))
+		})
 	}
 }
 FloatBox2DTest new() run()

--- a/test/math/IntBox2DTest.ooc
+++ b/test/math/IntBox2DTest.ooc
@@ -35,6 +35,14 @@ IntBox2DTest: class extends Fixture {
 		this add("casts", func {
 //			FIXME: We have no integer versions of anything yet
 		})
+		this add("setSize", func {
+			box := IntBox2D new(1, 1, 4, 4)
+			changedBox := box setSize(IntSize2D new(2, 2))
+			expect(changedBox left, is equal to(2))
+			expect(changedBox right, is equal to(4))
+			expect(changedBox top, is equal to(2))
+			expect(changedBox bottom, is equal to(4))
+		})
 		this add("scale", func {
 			box := IntBox2D new(1, 1, 4, 4)
 			doubledBox := box scale(2.0f)
@@ -50,8 +58,8 @@ IntBox2DTest: class extends Fixture {
 		})
 		this add("enlarge", func {
 			box := IntBox2D new(1, 1, 4, 4)
-			enlargedBox := box enlarge(IntSize2D new(6, 6))
-			notEnlargedBox := box enlarge(IntSize2D new(3, 3))
+			enlargedBox := box enlargeTo(IntSize2D new(6, 6))
+			notEnlargedBox := box enlargeTo(IntSize2D new(3, 3))
 			expect(enlargedBox left, is equal to(0))
 			expect(enlargedBox top, is equal to(0))
 			expect(enlargedBox right, is equal to(6))
@@ -60,8 +68,8 @@ IntBox2DTest: class extends Fixture {
 		})
 		this add("reduce", func {
 			box := IntBox2D new(1, 1, 4, 4)
-			reducedBox := box reduce(IntSize2D new(2, 2))
-			notReducedBox := box reduce(IntSize2D new(6, 6))
+			reducedBox := box reduceTo(IntSize2D new(2, 2))
+			notReducedBox := box reduceTo(IntSize2D new(6, 6))
 			expect(reducedBox left, is equal to(2))
 			expect(reducedBox top, is equal to(2))
 			expect(reducedBox right, is equal to(4))

--- a/test/math/IntBox2DTest.ooc
+++ b/test/math/IntBox2DTest.ooc
@@ -35,9 +35,9 @@ IntBox2DTest: class extends Fixture {
 		this add("casts", func {
 //			FIXME: We have no integer versions of anything yet
 		})
-		this add("setSize", func {
+		this add("resizeTo", func {
 			box := IntBox2D new(1, 1, 4, 4)
-			changedBox := box setSize(IntSize2D new(2, 2))
+			changedBox := box resizeTo(IntSize2D new(2, 2))
 			expect(changedBox left, is equal to(2))
 			expect(changedBox right, is equal to(4))
 			expect(changedBox top, is equal to(2))

--- a/test/math/IntBox2DTest.ooc
+++ b/test/math/IntBox2DTest.ooc
@@ -68,8 +68,8 @@ IntBox2DTest: class extends Fixture {
 		})
 		this add("reduce", func {
 			box := IntBox2D new(1, 1, 4, 4)
-			reducedBox := box reduceTo(IntSize2D new(2, 2))
-			notReducedBox := box reduceTo(IntSize2D new(6, 6))
+			reducedBox := box shrinkTo(IntSize2D new(2, 2))
+			notReducedBox := box shrinkTo(IntSize2D new(6, 6))
 			expect(reducedBox left, is equal to(2))
 			expect(reducedBox top, is equal to(2))
 			expect(reducedBox right, is equal to(4))

--- a/test/math/IntBox2DTest.ooc
+++ b/test/math/IntBox2DTest.ooc
@@ -35,6 +35,19 @@ IntBox2DTest: class extends Fixture {
 		this add("casts", func {
 //			FIXME: We have no integer versions of anything yet
 		})
+		this add("scale", func {
+			box := FloatBox2D new(1, 1, 4, 4)
+			doubledBox := box scale(2.0f)
+			halfBox := box scale(0.5f)
+			expect(doubledBox left, is equal to(-1))
+			expect(doubledBox right, is equal to(7))
+			expect(doubledBox top, is equal to(-1))
+			expect(doubledBox bottom, is equal to(7))
+			expect(halfBox left, is equal to(2))
+			expect(halfBox right, is equal to(4))
+			expect(halfBox top, is equal to(2))
+			expect(halfBox bottom, is equal to(4))
+		})
 	}
 }
 IntBox2DTest new() run()

--- a/test/math/IntBox2DTest.ooc
+++ b/test/math/IntBox2DTest.ooc
@@ -36,7 +36,7 @@ IntBox2DTest: class extends Fixture {
 //			FIXME: We have no integer versions of anything yet
 		})
 		this add("scale", func {
-			box := FloatBox2D new(1, 1, 4, 4)
+			box := IntBox2D new(1, 1, 4, 4)
 			doubledBox := box scale(2.0f)
 			halfBox := box scale(0.5f)
 			expect(doubledBox left, is equal to(-1))
@@ -47,6 +47,26 @@ IntBox2DTest: class extends Fixture {
 			expect(halfBox right, is equal to(4))
 			expect(halfBox top, is equal to(2))
 			expect(halfBox bottom, is equal to(4))
+		})
+		this add("enlarge", func {
+			box := IntBox2D new(1, 1, 4, 4)
+			enlargedBox := box enlarge(IntSize2D new(6, 6))
+			notEnlargedBox := box enlarge(IntSize2D new(3, 3))
+			expect(enlargedBox left, is equal to(0))
+			expect(enlargedBox top, is equal to(0))
+			expect(enlargedBox right, is equal to(6))
+			expect(enlargedBox bottom, is equal to(6))
+			expect(notEnlargedBox == box, is true)
+		})
+		this add("reduce", func {
+			box := IntBox2D new(1, 1, 4, 4)
+			reducedBox := box reduce(IntSize2D new(2, 2))
+			notReducedBox := box reduce(IntSize2D new(6, 6))
+			expect(reducedBox left, is equal to(2))
+			expect(reducedBox top, is equal to(2))
+			expect(reducedBox right, is equal to(4))
+			expect(reducedBox bottom, is equal to(4))
+			expect(notReducedBox == box, is true)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #551 
Adds the following four functions to change the size without affecting the center of a `FloatBox2D` or `IntBox2D`:
- [x] `setSize`: a specified size
- [x] `scale`: change by a scale factor
- [x] `enlarge`: change to a size that is >= the Size passed to the function (if the box is already >= the Size argument, use this size)
- [x] `reduce`: a size that is <= the Size passed to the function (if the box is already <= the Size argument, use this size).

If this isn't what you meant of if you prefer other names, let me know.