### PR TITLE
Optimized some raster conversion methods

### DIFF
--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -111,22 +111,27 @@ RasterBgr: class extends RasterPacked {
 		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {
-		result := This new(original size)
-		row := result buffer pointer as Long
-		rowLength := result size width
-		rowEnd := row as ColorBgr* + rowLength
-		destination := row as ColorBgr*
-		f := func (color: ColorBgr) {
-			(destination as ColorBgr*)@ = color
-			destination += 1
-			if (destination >= rowEnd) {
-				row += result stride
-				destination = row as ColorBgr*
-				rowEnd = row as ColorBgr* + rowLength
+		result: This
+		if (original instanceOf?(This))
+			result = (original as This) copy()
+		else {
+			result = This new(original size)
+			row := result buffer pointer as Long
+			rowLength := result size width
+			rowEnd := row as ColorBgr* + rowLength
+			destination := row as ColorBgr*
+			f := func (color: ColorBgr) {
+				(destination as ColorBgr*)@ = color
+				destination += 1
+				if (destination >= rowEnd) {
+					row += result stride
+					destination = row as ColorBgr*
+					rowEnd = row as ColorBgr* + rowLength
+				}
 			}
+			original apply(f)
+			(f as Closure) dispose()
 		}
-		original apply(f)
-		(f as Closure) dispose()
 		result
 	}
 	operator [] (x, y: Int) -> ColorBgr { this isValidIn(x, y) ? ((this buffer pointer + y * this stride) as ColorBgr* + x)@ : ColorBgr new(0, 0, 0) }

--- a/source/draw/RasterBgra.ooc
+++ b/source/draw/RasterBgra.ooc
@@ -121,22 +121,27 @@ RasterBgra: class extends RasterPacked {
 		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {
-		result := This new(original size)
-		row := result buffer pointer as Long
-		rowLength := result stride
-		rowEnd := row + rowLength
-		destination := row as ColorBgra*
-		f := func (color: ColorBgr) {
-			(destination as ColorBgra*)@ = ColorBgra new(color, 255)
-			destination += 1
-			if (destination >= rowEnd) {
-				row += result stride
-				destination = row as ColorBgra*
-				rowEnd = row + rowLength
+		result: This
+		if (original instanceOf?(This))
+			result = (original as This) copy()
+		else {
+			result = This new(original size)
+			row := result buffer pointer as Long
+			rowLength := result stride
+			rowEnd := row + rowLength
+			destination := row as ColorBgra*
+			f := func (color: ColorBgr) {
+				(destination as ColorBgra*)@ = ColorBgra new(color, 255)
+				destination += 1
+				if (destination >= rowEnd) {
+					row += result stride
+					destination = row as ColorBgra*
+					rowEnd = row + rowLength
+				}
 			}
+			original apply(f)
+			(f as Closure) dispose()
 		}
-		original apply(f)
-		(f as Closure) dispose()
 		result
 	}
 	operator [] (x, y: Int) -> ColorBgra { this isValidIn(x, y) ? ((this buffer pointer + y * this stride) as ColorBgra* + x)@ : ColorBgra new(0, 0, 0, 0) }

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -107,21 +107,27 @@ RasterMonochrome: class extends RasterPacked {
 		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntSize2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {
-		result := This new(original size)
-		row := result buffer pointer as Long
-		rowLength := result stride
-		rowEnd := row + rowLength
-		destination := row
-		f := func (color: ColorMonochrome) {
-			(destination as ColorMonochrome*)@ = color
-			destination += 1
-			if (destination >= rowEnd) {
-				row += result stride
-				destination = row
-				rowEnd = row + rowLength
+		result: This
+		if (original instanceOf?(This))
+			result = (original as This) copy()
+		else {
+			result = This new(original size)
+			row := result buffer pointer as Long
+			rowLength := result stride
+			rowEnd := row + rowLength
+			destination := row
+			f := func (color: ColorMonochrome) {
+				(destination as ColorMonochrome*)@ = color
+				destination += 1
+				if (destination >= rowEnd) {
+					row += result stride
+					destination = row
+					rowEnd = row + rowLength
+				}
 			}
+			original apply(f)
+			(f as Closure) dispose()
 		}
-		original apply(f)
 		result
 	}
 

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -118,21 +118,27 @@ RasterUv: class extends RasterPacked {
 		result
 	}
 	convertFrom: static func (original: RasterImage) -> This {
-		result := This new(original size)
-		row := result buffer pointer
-		rowLength := result size width
-		rowEnd := row as ColorUv* + rowLength
-		destination := row as ColorUv*
-		f := func (color: ColorYuv) {
-			(destination as ColorUv*)@ = ColorUv new(color u, color v)
-			destination += 1
-			if (destination >= rowEnd) {
-				row += result stride
-				destination = row as ColorUv*
-				rowEnd = row as ColorUv* + rowLength
+		result: This
+		if (original instanceOf?(This))
+			result = (original as This) copy()
+		else {
+			result = This new(original size)
+			row := result buffer pointer
+			rowLength := result size width
+			rowEnd := row as ColorUv* + rowLength
+			destination := row as ColorUv*
+			f := func (color: ColorYuv) {
+				(destination as ColorUv*)@ = ColorUv new(color u, color v)
+				destination += 1
+				if (destination >= rowEnd) {
+					row += result stride
+					destination = row as ColorUv*
+					rowEnd = row as ColorUv* + rowLength
+				}
 			}
+			original apply(f)
+			(f as Closure) dispose()
 		}
-		original apply(f)
 		result
 	}
 

--- a/source/draw/RasterYuv420Planar.ooc
+++ b/source/draw/RasterYuv420Planar.ooc
@@ -96,42 +96,48 @@ RasterYuv420Planar: class extends RasterYuvPlanar {
 	}
 	apply: func ~monochrome (action: Func(ColorMonochrome)) { this apply(ColorConvert fromYuv(action)) }
 	convertFrom: static func (original: RasterImage) -> This {
-		result := This new(original size)
-		y := 0
-		x := 0
-		width := result size width
-		yRow := result y buffer pointer
-		yDestination := yRow
-		uRow := result u buffer pointer
-		uDestination := uRow
-		vRow := result v buffer pointer
-		vDestination := vRow
-		//		C#: original.Apply(color => *((Color.Bgra*)destination++) = new Color.Bgra(color, 255));
-		f := func (color: ColorYuv) {
-			(yDestination)@ = color y
-			yDestination += 1
-			if (x % 2 == 0 && y % 2 == 0) {
-				uDestination@ = color u
-				uDestination += 1
-				vDestination@ = color v
-				vDestination += 1
-			}
-			x += 1
-			if (x >= width) {
-				x = 0
-				y += 1
+		result: This
+		if (original instanceOf?(This))
+			result = (original as This) copy()
+		else {
+			result = This new(original size)
+			y := 0
+			x := 0
+			width := result size width
+			yRow := result y buffer pointer
+			yDestination := yRow
+			uRow := result u buffer pointer
+			uDestination := uRow
+			vRow := result v buffer pointer
+			vDestination := vRow
+			//		C#: original.Apply(color => *((Color.Bgra*)destination++) = new Color.Bgra(color, 255));
+			f := func (color: ColorYuv) {
+				(yDestination)@ = color y
+				yDestination += 1
+				if (x % 2 == 0 && y % 2 == 0) {
+					uDestination@ = color u
+					uDestination += 1
+					vDestination@ = color v
+					vDestination += 1
+				}
+				x += 1
+				if (x >= width) {
+					x = 0
+					y += 1
 
-				yRow += result y stride
-				yDestination = yRow
-				if (y % 2 == 0) {
-					uRow += result u stride
-					uDestination = uRow
-					vRow += result v stride
-					vDestination = vRow
+					yRow += result y stride
+					yDestination = yRow
+					if (y % 2 == 0) {
+						uRow += result u stride
+						uDestination = uRow
+						vRow += result v stride
+						vDestination = vRow
+					}
 				}
 			}
+			original apply(f)
+			(f as Closure) dispose()
 		}
-		original apply(f)
 		result
 	}
 	operator [] (x, y: Int) -> ColorYuv {

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -182,41 +182,45 @@ RasterYuv420Semiplanar: class extends RasterYuvSemiplanar {
 		this uv[x / 2, y / 2] = ColorUv new(value u, value v)
 	}
 	convertFrom: static func (original: RasterImage) -> This {
-		result := This new(original size)
-		//		"RasterYuv420 init ~fromRasterImage, original: (#{original size}), this: (#{this size}), y stride #{this y stride}" println()
-		y := 0
-		x := 0
-		width := result size width
-		yRow := result y buffer pointer
-		yDestination := yRow
-		uvRow := result uv buffer pointer
-		uvDestination := uvRow
-		totalOffset := 0
-		//		C#: original.Apply(color => *((Color.Bgra*)destination++) = new Color.Bgra(color, 255));
-		f := func (color: ColorYuv) {
-			yDestination@ = color y
-			yDestination += 1
-			if (x % 2 == 0 && y % 2 == 0 && totalOffset < result uv buffer size) {
-				uvDestination@ = color v
-				uvDestination += 1
-				uvDestination@ = color u
-				uvDestination += 1
-				totalOffset += 2
-			}
-			x += 1
-			if (x >= width) {
-				x = 0
-				y += 1
-				yRow += result y stride
-				yDestination = yRow
-				if (y % 2 == 0) {
-					uvRow += result uv stride
-					uvDestination = uvRow
+		result: This
+		if (original instanceOf?(This))
+			result = (original as This) copy()
+		else {
+			result = This new(original size)
+			y := 0
+			x := 0
+			width := result size width
+			yRow := result y buffer pointer
+			yDestination := yRow
+			uvRow := result uv buffer pointer
+			uvDestination := uvRow
+			totalOffset := 0
+			//		C#: original.Apply(color => *((Color.Bgra*)destination++) = new Color.Bgra(color, 255));
+			f := func (color: ColorYuv) {
+				yDestination@ = color y
+				yDestination += 1
+				if (x % 2 == 0 && y % 2 == 0 && totalOffset < result uv buffer size) {
+					uvDestination@ = color v
+					uvDestination += 1
+					uvDestination@ = color u
+					uvDestination += 1
+					totalOffset += 2
+				}
+				x += 1
+				if (x >= width) {
+					x = 0
+					y += 1
+					yRow += result y stride
+					yDestination = yRow
+					if (y % 2 == 0) {
+						uvRow += result uv stride
+						uvDestination = uvRow
+					}
 				}
 			}
+			original apply(f)
+			(f as Closure) dispose()
 		}
-		original apply(f)
-		(f as Closure) dispose()
 		result
 	}
 	open: static func (filename: String) -> This {


### PR DESCRIPTION
Raster conversion methods use direct copy if converting from the same image type. It is faster than creating a closure and applying it pixel by pixel.
For example:
> RasterBgr from RasterBgr (with closure)
> 21.408001 msec.
> RasterBgr from RasterBgr (direct copy)
> 0.0507032 msec.

There is still room for optimization left (`RasterMonochrome` from `RasterYuvPlanar` - direct copy of `y` channel etc.), but I guess it is a good start.