### PR TITLE
Add FloatBox2D pad~fractionAverage().

### DIFF
--- a/source/math/FloatBox2D.ooc
+++ b/source/math/FloatBox2D.ooc
@@ -60,6 +60,9 @@ FloatBox2D: cover {
 	pad: func ~fraction (pad: Float) -> This {
 		this pad(pad * this size / 2.0f)
 	}
+	padFractionAverage: func (pad: Float) -> This {
+		this pad(pad * (this size width + this size height) / 2.0f)
+	}
 	shrink: func ~fraction (margin: Float) -> This {
 		this pad(-margin * this height / 2.0f)
 	}


### PR DESCRIPTION
Example:
```
FloatBox2D box = FloatBox2D new(FloatPoint new(0, 0), FloatSize(100, 80))
FloatBox2D box2 = box pad~fractionAverage(0.2f) 
```
Then `box2`'s boundaries are`0.2f * (100 + 80) / 2.0 = 18` pixels shifted outwards compared to `box`.