### PR TITLE
Removed exceptions in Transform classes

### DIFF
--- a/source/math/FloatTransform2D.ooc
+++ b/source/math/FloatTransform2D.ooc
@@ -35,7 +35,7 @@ FloatTransform2D: cover {
 		result := 0.0f
 		version (safe) {
 			if (x < 0 || x > 2 || y < 0 || y > 2)
-				raise("Out of bounds in FloatTransform2D get operator")
+				raise("Out of bounds in FloatTransform2D get operator (#{x}, #{y})")
 		}
 		match (x) {
 			case 0 =>
@@ -68,10 +68,8 @@ FloatTransform2D: cover {
 	rotationZ ::= this b atan2(this a)
 	inverse: This { get {
 		determinant := this determinant
-		version (safe) {
-			if (determinant == 0)
-				raise("Determinant is zero in FloatTransform2D inverse()")
-		}
+		if (determinant == 0)
+			raise("Determinant is zero in FloatTransform2D inverse()")
 		This new(
 			(this e * this i - this h * this f) / determinant,
 			(this h * this c - this b * this i) / determinant,

--- a/source/math/FloatTransform2D.ooc
+++ b/source/math/FloatTransform2D.ooc
@@ -33,29 +33,29 @@ FloatTransform2D: cover {
 	a, b, c, d, e, f, g, h, i: Float
 	operator [] (x, y: Int) -> Float {
 		result := 0.0f
+		version (safe) {
+			if (x < 0 || x > 2 || y < 0 || y > 2)
+				raise("Out of bounds in FloatTransform2D get operator")
+		}
 		match (x) {
 			case 0 =>
 				match (y) {
 					case 0 => result = this a
 					case 1 => result = this b
 					case 2 => result = this c
-					case => OutOfBoundsException new(y, 3) throw()
 				}
 			case 1 =>
 				match (y) {
 					case 0 => result = this d
 					case 1 => result = this e
 					case 2 => result = this f
-					case => OutOfBoundsException new(y, 3) throw()
 				}
 			case 2 =>
 				match (y) {
 					case 0 => result = this g
 					case 1 => result = this h
 					case 2 => result = this i
-					case => OutOfBoundsException new(y, 3) throw()
 				}
-			case => OutOfBoundsException new(x, 3) throw()
 		}
 		result
 	}
@@ -68,6 +68,10 @@ FloatTransform2D: cover {
 	rotationZ ::= this b atan2(this a)
 	inverse: This { get {
 		determinant := this determinant
+		version (safe) {
+			if (determinant == 0)
+				raise("Determinant is zero in FloatTransform2D inverse()")
+		}
 		This new(
 			(this e * this i - this h * this f) / determinant,
 			(this h * this c - this b * this i) / determinant,

--- a/source/math/FloatTransform3D.ooc
+++ b/source/math/FloatTransform3D.ooc
@@ -35,6 +35,10 @@ FloatTransform3D: cover {
 	a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p: Float
 	operator [] (x, y: Int) -> Float {
 		result := 0.0f
+		version (safe) {
+			if (x < 0 || x > 3 || y < 0 || y > 3)
+				raise("Out of bounds in FloatTransform3D get operator")
+		}
 		match (x) {
 			case 0 =>
 				match (y) {
@@ -42,7 +46,6 @@ FloatTransform3D: cover {
 					case 1 => result = this b
 					case 2 => result = this c
 					case 3 => result = this d
-					case => OutOfBoundsException new(y, 4) throw()
 				}
 			case 1 =>
 				match (y) {
@@ -50,7 +53,6 @@ FloatTransform3D: cover {
 					case 1 => result = this f
 					case 2 => result = this g
 					case 3 => result = this h
-					case => OutOfBoundsException new(y, 4) throw()
 				}
 			case 2 =>
 				match (y) {
@@ -58,7 +60,6 @@ FloatTransform3D: cover {
 					case 1 => result = this j
 					case 2 => result = this k
 					case 3 => result = this l
-					case => OutOfBoundsException new(y, 4) throw()
 				}
 			case 3 =>
 				match (y) {
@@ -66,9 +67,7 @@ FloatTransform3D: cover {
 					case 1 => result = this n
 					case 2 => result = this o
 					case 3 => result = this p
-					case => OutOfBoundsException new(y, 4) throw()
 				}
-			case => OutOfBoundsException new(x, 4) throw()
 		}
 		result
 	}
@@ -94,8 +93,10 @@ FloatTransform3D: cover {
 		// If the determinant is 0, the resulting transform will be full of NaN values.
 		// No FloatTransform3D instance should have a determinant of 0, so
 		// throw an exception, because something has gone wrong, somewhere.
-		if (determinant == 0)
-			raise("determinant is zero in FloatTransform3D inverse()!")
+		version (safe) {
+			if (determinant == 0)
+				raise("Determinant is zero in FloatTransform3D inverse()")
+		}
 		a := (this f * this k * this p + this j * this o * this h + this n * this g * this l - this f * this o * this l - this j * this g * this p - this n * this k * this h) / determinant
 		e := (this e * this o * this l + this i * this g * this p + this m * this k * this h - this e * this k * this p - this i * this o * this h - this m * this g * this l) / determinant
 		i := (this e * this j * this p + this i * this n * this h + this m * this f * this l - this e * this n * this l - this i * this f * this p - this m * this j * this h) / determinant

--- a/source/math/FloatTransform3D.ooc
+++ b/source/math/FloatTransform3D.ooc
@@ -37,7 +37,7 @@ FloatTransform3D: cover {
 		result := 0.0f
 		version (safe) {
 			if (x < 0 || x > 3 || y < 0 || y > 3)
-				raise("Out of bounds in FloatTransform3D get operator")
+				raise("Out of bounds in FloatTransform3D get operator (#{x}, #{y})")
 		}
 		match (x) {
 			case 0 =>
@@ -93,10 +93,8 @@ FloatTransform3D: cover {
 		// If the determinant is 0, the resulting transform will be full of NaN values.
 		// No FloatTransform3D instance should have a determinant of 0, so
 		// throw an exception, because something has gone wrong, somewhere.
-		version (safe) {
-			if (determinant == 0)
-				raise("Determinant is zero in FloatTransform3D inverse()")
-		}
+		if (determinant == 0)
+			raise("Determinant is zero in FloatTransform3D inverse()")
 		a := (this f * this k * this p + this j * this o * this h + this n * this g * this l - this f * this o * this l - this j * this g * this p - this n * this k * this h) / determinant
 		e := (this e * this o * this l + this i * this g * this p + this m * this k * this h - this e * this k * this p - this i * this o * this h - this m * this g * this l) / determinant
 		i := (this e * this j * this p + this i * this n * this h + this m * this f * this l - this e * this n * this l - this i * this f * this p - this m * this j * this h) / determinant

--- a/source/math/IntTransform2D.ooc
+++ b/source/math/IntTransform2D.ooc
@@ -30,6 +30,10 @@ import structs/ArrayList
 IntTransform2D: cover {
 	a, b, c, d, e, f, g, h, i: Int
 	operator [] (x, y: Int) -> Int {
+		version (safe) {
+			if (x < 0 || x > 2 || y < 0 || y > 2)
+				raise("Out of bounds in IntTransform2D get operator")
+		}
 		result := 0
 		match (x) {
 			case 0 =>
@@ -37,23 +41,19 @@ IntTransform2D: cover {
 					case 0 => result = this a
 					case 1 => result = this b
 					case 2 => result = this c
-					case => OutOfBoundsException new(y, 3) throw()
 				}
 			case 1 =>
 				match (y) {
 					case 0 => result = this d
 					case 1 => result = this e
 					case 2 => result = this f
-					case => OutOfBoundsException new(y, 3) throw()
 				}
 			case 2 =>
 				match (y) {
 					case 0 => result = this g
 					case 1 => result = this h
 					case 2 => result = this i
-					case => OutOfBoundsException new(y, 3) throw()
 				}
-			case => OutOfBoundsException new(x, 3) throw()
 		}
 		result
 	}
@@ -61,6 +61,10 @@ IntTransform2D: cover {
 	translation ::= IntSize2D new(this g, this h)
 	inverse: This { get {
 		determinant := this determinant
+		version (safe) {
+			if (determinant == 0)
+				raise("Determinant is zero in FloatTransform2D inverse()")
+		}
 		This new(
 			(this e * this i - this h * this f) / determinant,
 			(this h * this c - this b * this i) / determinant,

--- a/source/math/IntTransform2D.ooc
+++ b/source/math/IntTransform2D.ooc
@@ -32,7 +32,7 @@ IntTransform2D: cover {
 	operator [] (x, y: Int) -> Int {
 		version (safe) {
 			if (x < 0 || x > 2 || y < 0 || y > 2)
-				raise("Out of bounds in IntTransform2D get operator")
+				raise("Out of bounds in IntTransform2D get operator (#{x}, #{y})")
 		}
 		result := 0
 		match (x) {
@@ -61,10 +61,8 @@ IntTransform2D: cover {
 	translation ::= IntSize2D new(this g, this h)
 	inverse: This { get {
 		determinant := this determinant
-		version (safe) {
-			if (determinant == 0)
-				raise("Determinant is zero in FloatTransform2D inverse()")
-		}
+		if (determinant == 0)
+			raise("Determinant is zero in FloatTransform2D inverse()")
 		This new(
 			(this e * this i - this h * this f) / determinant,
 			(this h * this c - this b * this i) / determinant,

--- a/test/math/FloatTransform3DTest.ooc
+++ b/test/math/FloatTransform3DTest.ooc
@@ -26,15 +26,8 @@ FloatTransform3DTest: class extends Fixture {
 		})
 		this add("determinant", func {
 			expect(transform0 determinant, is equal to(6.0f) within(this precision))
-			exception := false
 			transform := FloatTransform3D new()
-			try {
-				value := transform inverse
-			} catch {
-				exception = true
-			}
-			expect(exception, is true)
-			expect(transform determinant, is equal to(0.0f))
+			expect(transform determinant, is equal to(0.0f) within(this precision))
 		})
 		this add("inverse transform", func {
 			transform := FloatTransform3D new(0.035711678574190f, 0.849129305868777f, 0.933993247757551f, 0.678735154857773f, 0.757740130578333f, 0.743132468124916f, 0.392227019534168f, 0.655477890177557f, 0.171186687811562f, 0.706046088019609f, 0.031832846377421f, 0.276922984960890f)


### PR DESCRIPTION
Instead uses `raise()` inside `safe` blocks.