### PR TITLE
Cleanup of GraphicBufferAlignTest

### DIFF
--- a/test/draw/gpu/GraphicBufferAlignTest.ooc
+++ b/test/draw/gpu/GraphicBufferAlignTest.ooc
@@ -11,32 +11,31 @@ GraphicBufferAlignTest: class extends Fixture {
 		this add("Align", func {
 			GraphicBuffer _alignedWidth = Int[5] new()
 
-			for (i in 0 .. 5) {
+			for (i in 0 .. 5)
 				GraphicBuffer _alignedWidth[i] = (i + 1) * 16
-				println("Unpadded width: " + GraphicBuffer _alignedWidth[i])
-			}
-			expect((GraphicBuffer alignWidth(5) == 16), is true)
-			expect((GraphicBuffer alignWidth(16) == 16), is true)
-			expect((GraphicBuffer alignWidth(18) == 16), is true)
-			expect((GraphicBuffer alignWidth(30) == 32), is true)
-			expect((GraphicBuffer alignWidth(34) == 32), is true)
-			expect((GraphicBuffer alignWidth(78) == 80), is true)
-			expect((GraphicBuffer alignWidth(80) == 80), is true)
-			expect((GraphicBuffer alignWidth(90) == 80), is true)
 
-			expect((GraphicBuffer alignWidth(5, AlignWidth Floor) == 16), is true)
-			expect((GraphicBuffer alignWidth(16, AlignWidth Floor) == 16), is true)
-			expect((GraphicBuffer alignWidth(31, AlignWidth Floor) == 16), is true)
-			expect((GraphicBuffer alignWidth(80, AlignWidth Floor) == 80), is true)
-			expect((GraphicBuffer alignWidth(90, AlignWidth Floor) == 80), is true)
+			expect(GraphicBuffer alignWidth(5), is equal to(16))
+			expect(GraphicBuffer alignWidth(16), is equal to(16))
+			expect(GraphicBuffer alignWidth(18), is equal to(16))
+			expect(GraphicBuffer alignWidth(30), is equal to(32))
+			expect(GraphicBuffer alignWidth(34), is equal to(32))
+			expect(GraphicBuffer alignWidth(78), is equal to(80))
+			expect(GraphicBuffer alignWidth(80), is equal to(80))
+			expect(GraphicBuffer alignWidth(90), is equal to(80))
 
-			expect((GraphicBuffer alignWidth(0, AlignWidth Ceiling) == 16), is true)
-			expect((GraphicBuffer alignWidth(16, AlignWidth Ceiling) == 16), is true)
-			expect((GraphicBuffer alignWidth(16, AlignWidth Ceiling) == 16), is true)
-			expect((GraphicBuffer alignWidth(17, AlignWidth Ceiling) == 32), is true)
-			expect((GraphicBuffer alignWidth(65, AlignWidth Ceiling) == 80), is true)
-			expect((GraphicBuffer alignWidth(80, AlignWidth Ceiling) == 80), is true)
-			expect((GraphicBuffer alignWidth(90, AlignWidth Ceiling) == 80), is true)
+			expect(GraphicBuffer alignWidth(5, AlignWidth Floor), is equal to(16))
+			expect(GraphicBuffer alignWidth(16, AlignWidth Floor), is equal to(16))
+			expect(GraphicBuffer alignWidth(31, AlignWidth Floor), is equal to(16))
+			expect(GraphicBuffer alignWidth(80, AlignWidth Floor), is equal to(80))
+			expect(GraphicBuffer alignWidth(90, AlignWidth Floor), is equal to(80))
+
+			expect(GraphicBuffer alignWidth(0, AlignWidth Ceiling), is equal to(16))
+			expect(GraphicBuffer alignWidth(16, AlignWidth Ceiling), is equal to(16))
+			expect(GraphicBuffer alignWidth(16, AlignWidth Ceiling), is equal to(16))
+			expect(GraphicBuffer alignWidth(17, AlignWidth Ceiling), is equal to(32))
+			expect(GraphicBuffer alignWidth(65, AlignWidth Ceiling), is equal to(80))
+			expect(GraphicBuffer alignWidth(80, AlignWidth Ceiling), is equal to(80))
+			expect(GraphicBuffer alignWidth(90, AlignWidth Ceiling), is equal to(80))
 		})
 	}
 }


### PR DESCRIPTION
Cleaned up the test and got rid of the `Unpadded width:` output. It *could* be a Debug print statement, but I don't see the point here - I would have to look at the code anyway to know what the original values were, and the contents of `_alignedWidth` are obvious from there.