### PR TITLE
x11 window without opengl

### DIFF
--- a/source/ui/x11/X11Window.ooc
+++ b/source/ui/x11/X11Window.ooc
@@ -17,10 +17,17 @@
 use ooc-math
 use ooc-ui
 import include/x11
+use ooc-draw
 
 version(unix || apple) {
 X11Window: class extends NativeWindow {
+	_x11GraphicsContext: GraphicsContextX11
+	_defaultScreen := 0
+	_displayDepth := 0
+	_cacheSize: IntSize2D
+	_xImage: XImageOoc*
 	init: func (size: IntSize2D, title: String) {
+		this _xImage = null
 		/* Note: ":0" is the usual identifier for the default display but this should be read from the DISPLAY variable in the system by passing null as parameter,
 		i.e. this _display = XOpenDisplay(null) */
 		display := XOpenDisplay(null)
@@ -30,10 +37,15 @@ X11Window: class extends NativeWindow {
 		}
 		if (display == null)
 			raise("Unable to open X Display")
+		this _defaultScreen = XDefaultScreen(display)
+		this _displayDepth = DefaultDepth(display, this _defaultScreen)
 		root: Long = DefaultRootWindow(display)
 		swa: XSetWindowAttributesOoc
 		swa eventMask = ExposureMask | PointerMotionMask | KeyPressMask | ButtonPressMask
 		backend := XCreateWindow(display, root, 0, 0, size width, size height, 0u, CopyFromParent as Int, InputOutput as UInt, null, CWEventMask, swa&)
+
+		this _x11GraphicsContext = XCreateGC(display, backend, 0, 0)
+		XSetBackground(display, this _x11GraphicsContext, 0)
 		//Disable fit to screen
 		sh: XSizeHintsOoc
 		sh width = sh min_width = size width
@@ -52,8 +64,25 @@ X11Window: class extends NativeWindow {
 	}
 	resize: func (size: IntSize2D) { XResizeWindow(this display, this backend, size width, size height) }
 	free: override func {
+		if (this _xImage)
+			XDestroyImage(this _xImage)
+		XFreeGC(this display, this _x11GraphicsContext)
+		XDestroyWindow(this display, this backend)
 		XCloseDisplay(this display)
 		super()
+	}
+	draw: func (image: RasterBgra) {
+		if (this _cacheSize != image size) {
+			if (this _xImage)
+				XDestroyImage(this _xImage)
+			imageData := gc_malloc(image height * image stride * 4)
+			this _xImage = XCreateImage(this display, CopyFromParent, this _displayDepth, ZPixmap, 0, imageData, image width, image height, 8, 0)
+			this _cacheSize = image size
+		}
+		image swapRedBlue()
+		memcpy(this _xImage@ data, image buffer pointer, image buffer size)
+		XClearWindow(this display, this backend)
+		XPutImage(this display, this backend, this _x11GraphicsContext, this _xImage, 0, 0, 0, 0, image width, image height)
 	}
 }
 }

--- a/source/ui/x11/include/x11.ooc
+++ b/source/ui/x11/include/x11.ooc
@@ -72,6 +72,8 @@ XEventOoc: cover from XEvent {
 	xkey: extern XKeyEventOoc
 }
 
+GraphicsContextX11: cover from GC
+
 XOpenDisplay: extern func (displayName: Char*) -> Pointer
 XCloseDisplay: extern func (display: Pointer) -> Int
 XCreateWindow: extern func (display: Pointer, window: Long, x, y: Int,
@@ -86,6 +88,23 @@ XFlush: extern func (display: Pointer)
 XSendEvent: extern func (display: Pointer, window: Long, propagate: Bool, event_mask: Long, event_send: XEventOoc*)
 XClearWindow: extern func (display: Pointer, window: Long)
 XMoveWindow: extern func (display: Pointer, window: Long, x, y: Int)
+XDefaultScreen: extern func (display: Pointer) -> Int
+DefaultDepth: extern func (display: Pointer, screen: Int) -> Int
+XSetBackground: extern func (...)
+XCreateGC: extern func (...) -> GraphicsContextX11
+XFreeGC: extern func (...)
+XDestroyWindow: extern func (...)
+
+XImageOoc: cover from XImage {
+	width, height, xoffset, format: Int
+	data: Char*
+	byteOrder, bitmapUnit, bitmapBitOrder, bitmapPad, depth, bytesPerLine, bitsPerPixel: Int
+	redMask, greenMask, blueMask: ULong
+}
+XCreateImage: extern func (...) -> XImageOoc*
+XPutImage: extern func (...)
+XDestroyImage: extern func (image: XImageOoc*)
+XPutPixel: extern func (...)
 
 XKeyEventOoc: cover from XKeyEvent {
 	type: extern Int
@@ -104,6 +123,8 @@ XKeyEventOoc: cover from XKeyEvent {
 	keycode: extern UInt
 	sameScreen: extern (same_screen) Bool
 }
+
+ZPixmap: extern const Long
 
 //XNextEvent: extern func(Pointer, XEvent) -> Int
 

--- a/source/widgets/DisplayWindow.ooc
+++ b/source/widgets/DisplayWindow.ooc
@@ -25,8 +25,8 @@ DisplayWindow: abstract class {
 	draw: abstract func (image: Image)
 	refresh: virtual func
 	create: static func (size: IntSize2D, title: String) -> This {
-		version((unix || apple) && !gpuOff)
-			return UnixWindow new(size, title)
+		version(unix || apple)
+			return UnixWindow create(size, title)
 		version(windows)
 			return Win32DisplayWindow new(size, title)
 		raise("Platform not supported (DisplayWindow)")


### PR DESCRIPTION
After merging this it is possible to use `gpuOff` version of the other project on linux.
It uses OpenGL as before when running with GPU.

It fails to clear the window with background color, I think this is because we do not process any events from the window system event queue (normally you should draw on the window only on `paint / refresh` event, our approach is kind of brute force). The same code clears the window if you have an event loop running, maybe we should fix this (it would allow us to close the instance of the program when pressing the `X` button on window status bar).