### PR TITLE
Tests now print time in output

### DIFF
--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -34,6 +34,7 @@ Fixture: abstract class {
 		failures := VectorList<TestFailedException> new()
 		result := true
 		This _print(this name + " ")
+		timer := ClockTimer new() . start()
 		for (test in tests) {
 			This _expectCount = 0
 			r := true
@@ -47,7 +48,8 @@ Fixture: abstract class {
 			}
 			This _print(r ? "." : "f")
 		}
-		This _print(result ? " done\n" : " failed\n")
+		This _print(result ? " done" : " failed")
+		This _print(" in %.2f s\n" format(timer stop() / 1000.0))
 		if (!result) {
 			for (f in failures) {
 				// If the constraint is a CompareConstraint and the value being tested is a Cell,
@@ -60,6 +62,7 @@ Fixture: abstract class {
 			This _testsFailed = true
 		}
 		failures free()
+		timer free()
 		result
 	}
 	createFailureMessage: func (failure: TestFailedException) -> Text {

--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -20,6 +20,7 @@ use ooc-collections
 import Constraints
 
 Fixture: abstract class {
+	totalTime: static Double
 	name: String
 	tests := VectorList<Test> new()
 	init: func (=name)
@@ -33,7 +34,7 @@ Fixture: abstract class {
 	run: func -> Bool {
 		failures := VectorList<TestFailedException> new()
 		result := true
-		This _print(this name + " ")
+		This _print(DateTime now toStringFormat("%hh:%mm:%ss") + " " + this name + " ")
 		timer := ClockTimer new() . start()
 		for (test in tests) {
 			This _expectCount = 0
@@ -49,7 +50,9 @@ Fixture: abstract class {
 			This _print(r ? "." : "f")
 		}
 		This _print(result ? " done" : " failed")
-		This _print(" in %.2f s\n" format(timer stop() / 1000.0))
+		testTime := timer stop() / 1000.0
+		This totalTime += testTime
+		This _print(" in %.2fs, total: %.2fs\n" format(testTime, This totalTime))
 		if (!result) {
 			for (f in failures) {
 				// If the constraint is a CompareConstraint and the value being tested is a Cell,


### PR DESCRIPTION
Fixes #603 
Example output:
```
13:54:08 TimeSpan ....... done in 0.00s, total: 18.95s
13:54:08 ReferenceCounter .. done in 0.01s, total: 18.95s
13:54:08 Promise .. done in 2.88s, total: 21.84s
13:54:09 TextBuilder ...... done in 0.00s, total: 21.84s
13:54:09 ThreadPool .... done in 4.97s, total: 26.81s
```