### PR TITLE
Suppressed leaks from DateTime in Fixture

### DIFF
--- a/kean.supp
+++ b/kean.supp
@@ -16,3 +16,9 @@
    ...
    fun:Constraints__IsConstraints___getequal__
 }
+{
+   datetime_tostringformat
+   Memcheck:Leak
+   ...
+   fun:DateTime__DateTime_toStringFormat
+}


### PR DESCRIPTION
Fixes https://github.com/cogneco/ooc-kean/issues/631
`toString` method in `DateTime` will be probably rewritten to use `Text` at some point.