### PR TITLE
Removed cancel() from win32 threads

### DIFF
--- a/source/sdk/threading/native/ThreadWin32.ooc
+++ b/source/sdk/threading/native/ThreadWin32.ooc
@@ -47,7 +47,9 @@ version(windows) {
         }
 
         cancel: func -> Bool {
-            this alive?() && TerminateThread(this handle, 0)
+            false
+            //this alive?() && TerminateThread(this handle, 0)
+            //TODO Find a better way to terminate Win32 threads, if any 
         }
 
         alive?: func -> Bool {

--- a/test/sdk/ThreadTest.ooc
+++ b/test/sdk/ThreadTest.ooc
@@ -7,7 +7,7 @@ ThreadTest: class extends Fixture {
 	init: func {
 		super("Thread")
 		this add("starting thread", This _testStartingThread)
-		this add("canceling thread", This _testCancelation)
+		version (!windows) { this add("canceling thread", This _testCancelation) }
 	}
 	_testStartingThread: static func {
 		threadStarted := Cell<Int> new(0)


### PR DESCRIPTION
Another step forward in making threaded things run smoothly on Windows and AppVeyor. The use of cancel is behind most of the problems.

Microsoft says `TerminateThread is a dangerous function that should only be used in the most extreme cases.`

Random people say:
```TerminateThread is able to kill threads that are currently holding critical sections deep within the Windows API, such as in the sockets layer. If a thread is killed while holding a critical section, that section stays locked forever, and your program can grind mysteriously to a halt. ```

```The warnings above are a gross understatement. TerminateThread is NOT a solution for shutting down worker threads. You will break your app, and it will fail randomly.```