### PR TITLE
Removed the pthreads install from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ install:
     bash install_rock.sh
 
     mv rock.exe C:\msys64\usr\bin\
-
-    mingw-get install pthreads
 build: off
 test_script:
 - cmd: bash test.sh nogpu -DgpuOff


### PR DESCRIPTION
We haven't had to use `pthreads` to compile rock for some time, and it's not the threading backend for Windows, so this only consumes time.
Right @jonathanudd ?