### PR TITLE
Fixed memory leak in CsvWriter

### DIFF
--- a/source/io/CsvWriter.ooc
+++ b/source/io/CsvWriter.ooc
@@ -36,10 +36,8 @@ CsvWriter: class {
 		result
 	}
 	open: static func ~string (filename: String) -> This {
-		result: This = null
 		file := File new(filename)
-		if (file exists?())
-			result = This new(FileWriter new(file))
+		result := This new(FileWriter new(file))
 		file free()
 		result
 	}

--- a/source/io/CsvWriter.ooc
+++ b/source/io/CsvWriter.ooc
@@ -29,10 +29,17 @@ CsvWriter: class {
 		}
 		this _fileWriter write("\r\n")
 	}
-	open: static func (filename: Text) -> This {
+	open: static func ~text (filename: Text) -> This {
+		filenameString := filename toString()
+		result := This open(filenameString)
+		filenameString free()
+		result
+	}
+	open: static func ~string (filename: String) -> This {
 		result: This = null
-		file := File new(filename toString())
-		result = This new(FileWriter new(file))
+		file := File new(filename)
+		if (file exists?())
+			result = This new(FileWriter new(file))
 		file free()
 		result
 	}


### PR DESCRIPTION
I forgot about the writer in the previous PR, so in the interest of symmetry, here is a fix for ```CsvWriter``` as well. @simonmika raised a good point regarding allowing ```String``` overloads in that the very purpose of ```Text``` was to force away the use of ```String``` (which is why I didn't make a ```String``` overload to begin with).

Anyway, I guess we could consider this a temporary fix until we rid ourselves of ```String```.