### PR TITLE
Suspended ThreadPoolTest

### DIFF
--- a/test/base/ThreadPoolTest.ooc
+++ b/test/base/ThreadPoolTest.ooc
@@ -2,7 +2,8 @@ use ooc-base
 use ooc-unit
 import threading/Thread
 
-ThreadPoolTest: class extends Fixture {
+//TODO Reimplement these tests once the problems with BlockedQueue have been fixed
+/*ThreadPoolTest: class extends Fixture {
 	init: func {
 		super("ThreadPool")
 		this add("threaded_noresult", func {
@@ -94,4 +95,5 @@ ThreadPoolTest: class extends Fixture {
 	}
 }
 
-ThreadPoolTest new() run()
+ThreadPoolTest new() run()*/
+"ThreadPool [TODO: Temporarily suspended]" println()


### PR DESCRIPTION
Quick and very ugly fix, but once problems with `BlockedQueue` are resolved we can reinstate it.
This will give us better reliability for the automatic tests.