### PR TITLE
Removed siphash.use from the SDK

### DIFF
--- a/source/sdk/siphash.use
+++ b/source/sdk/siphash.use
@@ -1,5 +1,0 @@
-Name: siphash
-Description: SipHash implementation in C
-SourcePath: hash
-Imports: siphash
-Additionals: ./hash/csiphash.c


### PR DESCRIPTION
The c file it refers to doesn't even exist.