### PR TITLE
Updated distance method in raster image classes

### DIFF
--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -63,13 +63,13 @@ RasterBgr: class extends RasterPacked {
 	}
 	distance: func (other: Image) -> Float {
 		result := 0.0f
-		if (!other)
+		if (!other || (this size != other size))
 			result = Float maximumValue
-//		else if (!other instanceOf?(This))
-//			FIXME
-//		else if (this size != other size)
-//			FIXME
-		else {
+		else if (!other instanceOf?(This)) {
+			converted := This convertFrom(other as RasterImage)
+			result = this distance(converted)
+			converted referenceCount decrease()
+		} else {
 			for (y in 0 .. this size height)
 				for (x in 0 .. this size width) {
 					c := this[x, y]

--- a/source/draw/RasterBgra.ooc
+++ b/source/draw/RasterBgra.ooc
@@ -65,13 +65,13 @@ RasterBgra: class extends RasterPacked {
 	}
 	distance: func (other: Image) -> Float {
 		result := 0.0f
-		if (!other)
+		if (!other || (this size != other size))
 			result = Float maximumValue
-//		else if (!other instanceOf?(This))
-//			FIXME
-//		else if (this size != other size)
-//			FIXME
-		else {
+		else if (!other instanceOf?(This)) {
+			converted := This convertFrom(other as RasterImage)
+			result = this distance(converted)
+			converted referenceCount decrease()
+		} else {
 			for (y in 0 .. this size height)
 				for (x in 0 .. this size width) {
 					c := this[x, y]

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -116,13 +116,13 @@ RasterMonochrome: class extends RasterPacked {
 	}
 	distance: override func (other: Image) -> Float {
 		result := 0.0f
-		if (!other)
+		if (!other || (this size != other size))
 			result = Float maximumValue
-//		else if (!other instanceOf?(This))
-//			FIXME
-//		else if (this size != other size)
-//			FIXME
-		else {
+		else if (!other instanceOf?(This)) {
+			converted := This convertFrom(other as RasterImage)
+			result = this distance(converted)
+			converted referenceCount decrease()
+		} else {
 			for (y in 0 .. this size height)
 				for (x in 0 .. this size width) {
 					c := this[x, y]

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -61,13 +61,13 @@ RasterUv: class extends RasterPacked {
 
 	distance: func (other: Image) -> Float {
 		result := 0.0f
-		if (!other)
+		if (!other || (this size != other size))
 			result = Float maximumValue
-//		else if (!other instanceOf?(This))
-//			FIXME
-//		else if (this size != other size)
-//			FIXME
-		else {
+		else if (!other instanceOf?(This)) {
+			converted := This convertFrom(other as RasterImage)
+			result = this distance(converted)
+			converted referenceCount decrease()
+		} else {
 			for (y in 0 .. this size height)
 				for (x in 0 .. this size width) {
 					c := this[x, y]

--- a/source/draw/RasterYuvPlanar.ooc
+++ b/source/draw/RasterYuvPlanar.ooc
@@ -67,12 +67,8 @@ RasterYuvPlanar: abstract class extends RasterPlanar {
 	}
 	distance: func (other: Image) -> Float {
 		result := 0.0f
-		if (!other)
+		if (!other || (this size != other size) || !other instanceOf?(This))
 			result = Float maximumValue
-//		else if (!other instanceOf?(This))
-//			FIXME
-//		else if (this size != other size)
-//			FIXME
 		else {
 			for (y in 0 .. this size height)
 				for (x in 0 .. this size width) {

--- a/source/draw/RasterYuvSemiplanar.ooc
+++ b/source/draw/RasterYuvSemiplanar.ooc
@@ -68,12 +68,8 @@ RasterYuvSemiplanar: abstract class extends RasterPlanar {
 	}
 	distance: func (other: Image) -> Float {
 		result := 0.0f
-		if (!other)
+		if (!other || (this size != other size) || !other instanceOf?(This))
 			result = Float maximumValue
-//		else if (!other instanceOf?(This))
-//			FIXME
-//		else if (this size != other size)
-//			FIXME
 		else {
 			for (y in 0 .. this size height)
 				for (x in 0 .. this size width) {


### PR DESCRIPTION
Cleaned up `distance` methods in raster images for https://github.com/cogneco/ooc-kean/issues/591 .
Since no one has a better idea, I suggest that for two images with different sizes we return "maximum" distance. It is better than previously returned zero (*="images are identical"*) anyway.