### PR TITLE
Removed siphash.use (again)

### DIFF
--- a/siphash.use
+++ b/siphash.use
@@ -1,5 +1,0 @@
-Name: siphash
-Description: SipHash implementation in C
-SourcePath: hash
-Imports: siphash
-Additionals: ./hash/csiphash.c


### PR DESCRIPTION
This file was removed from the sdk in #652 ...but we had two for some reason.