### PR TITLE
Only print Backtrace error messages once

### DIFF
--- a/source/sdk/lang/Backtrace.ooc
+++ b/source/sdk/lang/Backtrace.ooc
@@ -12,6 +12,7 @@ BacktraceHandler: class {
 
     // constants
     BACKTRACE_LENGTH := static 128
+    WARNED_ABOUT_FALLBACK := static false
     
     // singleton
     instance: static This
@@ -52,13 +53,19 @@ BacktraceHandler: class {
         } else {
             // fall back on execinfo? still informative
             version (linux || apple) {
-                stderr write("[lang/Backtrace] Falling back on execinfo.. (build extension if you want fancy backtraces)\n")
+                if (!WARNED_ABOUT_FALLBACK) {
+                    stderr write("[lang/Backtrace] Falling back on execinfo.. (build extension if you want fancy backtraces)\n")
+                    This WARNED_ABOUT_FALLBACK = true
+                }
                 length := backtrace(buffer, BACKTRACE_LENGTH)
                 return Backtrace new(buffer, length)
             }
 
             // no such luck, use a debugger :(
-            stderr write("[lang/Backtrace] No backtrace extension nor execinfo - use a debugger!\n")
+            if (!WARNED_ABOUT_FALLBACK) {
+                stderr write("[lang/Backtrace] No backtrace extension nor execinfo - use a debugger!\n")
+                This WARNED_ABOUT_FALLBACK = true
+            }
             gc_free(buffer)
             return null
         }

--- a/source/sdk/lang/Backtrace.ooc
+++ b/source/sdk/lang/Backtrace.ooc
@@ -53,7 +53,7 @@ BacktraceHandler: class {
         } else {
             // fall back on execinfo? still informative
             version (linux || apple) {
-                if (!WARNED_ABOUT_FALLBACK) {
+                if (!This WARNED_ABOUT_FALLBACK) {
                     stderr write("[lang/Backtrace] Falling back on execinfo.. (build extension if you want fancy backtraces)\n")
                     This WARNED_ABOUT_FALLBACK = true
                 }
@@ -62,7 +62,7 @@ BacktraceHandler: class {
             }
 
             // no such luck, use a debugger :(
-            if (!WARNED_ABOUT_FALLBACK) {
+            if (!This WARNED_ABOUT_FALLBACK) {
                 stderr write("[lang/Backtrace] No backtrace extension nor execinfo - use a debugger!\n")
                 This WARNED_ABOUT_FALLBACK = true
             }


### PR DESCRIPTION
Implements updates found in https://github.com/fasterthanlime/rock/commit/19bfc01a7904676f49a9cbb2626e7803df6484fb to only *once* print the error message `"[lang/Backtrace] No backtrace extension nor execinfo - use a debugger!\n"`. 

Cleans up the output in Appveyor and CircleCI.