### PR TITLE
Whitespace fixes to sdk/threading/native

### DIFF
--- a/source/sdk/threading/native/ConditionUnix.ooc
+++ b/source/sdk/threading/native/ConditionUnix.ooc
@@ -15,28 +15,28 @@ import ../Thread
 import MutexUnix
 
 ConditionUnix: class extends WaitCondition {
-  _backend: PThreadCond*
+	_backend: PThreadCond*
 
-  init: func {
-    this _backend = gc_malloc(PThreadCond size) as PThreadCond*
-    result := pthread_cond_init(this _backend, null)
-    if (result != 0)
-    	raise("Something went wrong when calling pthread_cond_init")
-  }
-  free: override func {
-    pthread_cond_destroy(this _backend)
-    gc_free(this _backend)
-    super()
-  }
-  wait: func (mutex: Mutex) -> Bool {
-    version(safe) {
-      if (mutex class != MutexUnix)
-        raise("ConditionUnix can work only with MutexUnix")
-    }
-    pthread_cond_wait(this _backend, mutex as MutexUnix _backend&) == 0
-  }
-  signal: func -> Bool { pthread_cond_signal(this _backend) == 0 }
-  broadcast: func -> Bool { pthread_cond_broadcast(this _backend) == 0 }
-}
+	init: func {
+		this _backend = gc_malloc(PThreadCond size) as PThreadCond*
+		result := pthread_cond_init(this _backend, null)
+		if (result != 0)
+			raise("Something went wrong when calling pthread_cond_init")
+	}
+	free: override func {
+		pthread_cond_destroy(this _backend)
+		gc_free(this _backend)
+		super()
+	}
+	wait: func (mutex: Mutex) -> Bool {
+		version(safe) {
+			if (mutex class != MutexUnix)
+				raise("ConditionUnix can work only with MutexUnix")
+		}
+		pthread_cond_wait(this _backend, mutex as MutexUnix _backend&) == 0
+	}
+	signal: func -> Bool { pthread_cond_signal(this _backend) == 0 }
+	broadcast: func -> Bool { pthread_cond_broadcast(this _backend) == 0 }
+	}
 
 }

--- a/source/sdk/threading/native/MutexUnix.ooc
+++ b/source/sdk/threading/native/MutexUnix.ooc
@@ -2,60 +2,60 @@ import ../Thread
 
 version(unix || apple) {
 
-    include pthread | (_XOPEN_SOURCE=500)
-    include unistd
+	include pthread | (_XOPEN_SOURCE=500)
+	include unistd
 
-    /* covers & extern functions */
-    PThreadMutex: cover from pthread_mutex_t
-    PThreadMutexAttr: cover from pthread_mutexattr_t
+	/* covers & extern functions */
+	PThreadMutex: cover from pthread_mutex_t
+	PThreadMutexAttr: cover from pthread_mutexattr_t
 
-    pthread_mutex_lock   : extern func (PThreadMutex*)
-    pthread_mutex_unlock : extern func (PThreadMutex*)
-    pthread_mutex_init   : extern func (PThreadMutex*, PThreadMutexAttr*)
-    pthread_mutex_destroy: extern func (PThreadMutex*)
+	pthread_mutex_lock: extern func (PThreadMutex*)
+	pthread_mutex_unlock: extern func (PThreadMutex*)
+	pthread_mutex_init: extern func (PThreadMutex*, PThreadMutexAttr*)
+	pthread_mutex_destroy: extern func (PThreadMutex*)
 
-    pthread_mutexattr_init: extern func (PThreadMutexAttr*)
-    pthread_mutexattr_settype: extern func (PThreadMutexAttr*, Int)
+	pthread_mutexattr_init: extern func (PThreadMutexAttr*)
+	pthread_mutexattr_settype: extern func (PThreadMutexAttr*, Int)
 
-    PTHREAD_MUTEX_RECURSIVE: extern Int
+	PTHREAD_MUTEX_RECURSIVE: extern Int
 
-    /**
-     * pthreads implementation of mutexes.
-     */
-    MutexUnix: class extends Mutex {
-      _backend: PThreadMutex
-        init: func {
-            pthread_mutex_init(this _backend&, null)
-        }
-        free: override func {
-          pthread_mutex_destroy(this _backend&)
-          super()
-        }
-        lock: func {
-            pthread_mutex_lock(this _backend&)
-        }
-        unlock: func {
-            pthread_mutex_unlock(this _backend&)
-        }
-    }
+	/**
+	 * pthreads implementation of mutexes.
+	 */
+	MutexUnix: class extends Mutex {
+		_backend: PThreadMutex
+		init: func {
+			pthread_mutex_init(this _backend&, null)
+		}
+		free: override func {
+			pthread_mutex_destroy(this _backend&)
+			super()
+		}
+		lock: func {
+			pthread_mutex_lock(this _backend&)
+		}
+		unlock: func {
+			pthread_mutex_unlock(this _backend&)
+		}
+	}
 
-    RecursiveMutexUnix: class extends RecursiveMutex {
-        _backend: PThreadMutex
-        init: func {
-        attr: PThreadMutexAttr
-        pthread_mutexattr_init(attr&)
-        pthread_mutexattr_settype(attr&, PTHREAD_MUTEX_RECURSIVE)
-        pthread_mutex_init(this _backend&, attr&)
-        }
-        free: override func {
-          pthread_mutex_destroy(this _backend&)
-          super()
-        }
-        lock: func {
-            pthread_mutex_lock(this _backend&)
-        }
-        unlock: func {
-            pthread_mutex_unlock(this _backend&)
-        }
-    }
+	RecursiveMutexUnix: class extends RecursiveMutex {
+		_backend: PThreadMutex
+		init: func {
+		attr: PThreadMutexAttr
+		pthread_mutexattr_init(attr&)
+		pthread_mutexattr_settype(attr&, PTHREAD_MUTEX_RECURSIVE)
+		pthread_mutex_init(this _backend&, attr&)
+		}
+		free: override func {
+			pthread_mutex_destroy(this _backend&)
+			super()
+		}
+		lock: func {
+			pthread_mutex_lock(this _backend&)
+		}
+		unlock: func {
+			pthread_mutex_unlock(this _backend&)
+		}
+	}
 }

--- a/source/sdk/threading/native/MutexWin32.ooc
+++ b/source/sdk/threading/native/MutexWin32.ooc
@@ -3,68 +3,68 @@ import native/win32/[types, errors]
 
 version(windows) {
 
-    include windows
+	include windows
 
-    /* covers & extern functions */
-    CreateMutex: extern func (Pointer, Bool, Pointer) -> Handle
-    ReleaseMutex: extern func (Handle)
-    CloseHandle: extern func (Handle)
+	/* covers & extern functions */
+	CreateMutex: extern func (Pointer, Bool, Pointer) -> Handle
+	ReleaseMutex: extern func (Handle)
+	CloseHandle: extern func (Handle)
 
-    WaitForSingleObject: extern func (...) -> Long // laziness
-    INFINITE: extern Long
+	WaitForSingleObject: extern func (...) -> Long // laziness
+	INFINITE: extern Long
 
-    /**
-     * Win32 implementation of mutexes.
-     */
-    MutexWin32: class extends Mutex {
-      _backend: Handle
-        init: func{
-            this _backend = CreateMutex (
-                null,  // default security attributes
-                false, // initially not owned
-                null)  // unnamed mutex
-        }
-        free: override func {
-          CloseHandle(this _backend)
-          super()
-        }
-        lock: func {
-          WaitForSingleObject(
-              this _backend, // handle to mutex
-              INFINITE         // no time-out interval
-          )
-        }
-        unlock: func {
-          ReleaseMutex(this _backend)
-        }
-    }
+	/**
+	 * Win32 implementation of mutexes.
+	 */
+	MutexWin32: class extends Mutex {
+		_backend: Handle
+		init: func {
+			this _backend = CreateMutex (
+				null, // default security attributes
+				false, // initially not owned
+				null) // unnamed mutex
+		}
+		free: override func {
+			CloseHandle(this _backend)
+			super()
+		}
+		lock: func {
+			WaitForSingleObject(
+				this _backend, // handle to mutex
+				INFINITE // no time-out interval
+			)
+		}
+		unlock: func {
+			ReleaseMutex(this _backend)
+		}
+	}
 
-    /**
-     * Win32 implementation of recursive mutexes.
-     *
-     * Apparently, Win32 mutexes are recursive by default, so this is just a
-     * copy of `MutexWin32`, which is by
-     */
-    RecursiveMutexWin32: class extends RecursiveMutex {
-        _backend: Handle
-        init: func{
-            this _backend = CreateMutex (
-                null,  // default security attributes
-                false, // initially not owned
-                null)  // unnamed mutex
-        }
-        free: override func {
-          CloseHandle(this _backend)
-          super()
-        }
-        lock: func {
-          WaitForSingleObject(
-              this _backend, // handle to mutex
-              INFINITE         // no time-out interval
-          )
-        }
-        unlock: func {
-          ReleaseMutex(this _backend)
-        }
-    }
+	/**
+	 * Win32 implementation of recursive mutexes.
+	 *
+	 * Apparently, Win32 mutexes are recursive by default, so this is just a
+	 * copy of `MutexWin32`, which is by
+	 */
+	RecursiveMutexWin32: class extends RecursiveMutex {
+		_backend: Handle
+		init: func {
+			this _backend = CreateMutex (
+				null, // default security attributes
+				false, // initially not owned
+				null) // unnamed mutex
+		}
+		free: override func {
+			CloseHandle(this _backend)
+			super()
+		}
+		lock: func {
+			WaitForSingleObject(
+				this _backend, // handle to mutex
+				INFINITE // no time-out interval
+			)
+		}
+		unlock: func {
+			ReleaseMutex(this _backend)
+		}
+	}
 }

--- a/source/sdk/threading/native/ThreadLocalUnix.ooc
+++ b/source/sdk/threading/native/ThreadLocalUnix.ooc
@@ -3,36 +3,36 @@ import ../Thread, ThreadUnix
 include unistd
 
 version(unix || apple) {
-    include pthread
+	include pthread
 
-    pthread_self: extern func -> PThread
-     
-    ThreadLocalUnix: class <T> extends ThreadLocal<T> {
-        values := HashMap<PThread, T> new()
-        valuesMutex := Mutex new()
+	pthread_self: extern func -> PThread
 
-        init: func ~unix {
-        
-        }
-        
-        set: func (value: T) {
-            valuesMutex lock()
-            values put(pthread_self(), value)
-            valuesMutex unlock()    
-        }
+	ThreadLocalUnix: class <T> extends ThreadLocal<T> {
+		values := HashMap<PThread, T> new()
+		valuesMutex := Mutex new()
 
-        get: func -> T {
-            valuesMutex lock()
-            value := values get(pthread_self())
-            valuesMutex unlock()
-            value
-        }
+		init: func ~unix {
 
-        hasValue?: func -> Bool {
-            valuesMutex lock()
-            has := values contains?(pthread_self())
-            valuesMutex unlock()
-            has
-        }
-    }
+		}
+
+		set: func (value: T) {
+			valuesMutex lock()
+			values put(pthread_self(), value)
+			valuesMutex unlock()
+		}
+
+		get: func -> T {
+			valuesMutex lock()
+			value := values get(pthread_self())
+			valuesMutex unlock()
+			value
+		}
+
+		hasValue?: func -> Bool {
+			valuesMutex lock()
+			has := values contains?(pthread_self())
+			valuesMutex unlock()
+			has
+		}
+	}
 }

--- a/source/sdk/threading/native/ThreadLocalWin32.ooc
+++ b/source/sdk/threading/native/ThreadLocalWin32.ooc
@@ -3,37 +3,36 @@ import ../Thread, ThreadWin32
 include unistd
 
 version(windows) {
-    include windows
+	include windows
 
-    GetCurrentThreadId: extern func -> Long // TODO: also laziness.
-     
-    ThreadLocalWin32: class <T> extends ThreadLocal<T> {
-        values := HashMap<Long, T> new()
-        valuesMutex := Mutex new()
+	GetCurrentThreadId: extern func -> Long // TODO: also laziness.
 
-        init: func ~windows {
-        
-        }
-        
-        set: func (value: T) {
-            valuesMutex lock()
-            values put(GetCurrentThreadId(), value)
-            valuesMutex unlock()    
-        }
+	ThreadLocalWin32: class <T> extends ThreadLocal<T> {
+		values := HashMap<Long, T> new()
+		valuesMutex := Mutex new()
 
-        get: func -> T {
-            valuesMutex lock()
-            value := values get(GetCurrentThreadId())
-            valuesMutex unlock()
-            value
-        }
+		init: func ~windows {
 
-        hasValue?: func -> Bool {
-            valuesMutex lock()
-            has := values contains?(GetCurrentThreadId())
-            valuesMutex unlock()
-            has
-        }
-    }
+		}
+
+		set: func (value: T) {
+			valuesMutex lock()
+			values put(GetCurrentThreadId(), value)
+			valuesMutex unlock()
+		}
+
+		get: func -> T {
+			valuesMutex lock()
+			value := values get(GetCurrentThreadId())
+			valuesMutex unlock()
+			value
+		}
+
+		hasValue?: func -> Bool {
+			valuesMutex lock()
+			has := values contains?(GetCurrentThreadId())
+			valuesMutex unlock()
+			has
+		}
+	}
 }
-

--- a/source/sdk/threading/native/ThreadUnix.ooc
+++ b/source/sdk/threading/native/ThreadUnix.ooc
@@ -4,124 +4,124 @@ include unistd
 
 version(unix || apple) {
 
-    /**
-     * pthreads implementation of threads.
-     */
-    ThreadUnix: class extends Thread {
+	/**
+	 * pthreads implementation of threads.
+	 */
+	ThreadUnix: class extends Thread {
 
-        pthread: PThread
+		pthread: PThread
 
-        init: func ~unix (=_code) {}
+		init: func ~unix (=_code) {}
 
-        start: func -> Bool {
-            result := pthread_create(pthread&, null, _code as Closure thunk, _code as Closure context)
-            (result == 0)
-        }
+		start: func -> Bool {
+			result := pthread_create(pthread&, null, _code as Closure thunk, _code as Closure context)
+			(result == 0)
+		}
 
-        wait: func -> Bool {
-            result := pthread_join(pthread, null)
-            (result == 0)
-        }
+		wait: func -> Bool {
+			result := pthread_join(pthread, null)
+			(result == 0)
+		}
 
-        wait: func ~timed (seconds: Double) -> Bool {
-          version (apple || android) { return __fake_timedjoin(seconds) }
-          else {
-            ts: TimeSpec
-            __setupTimeout(ts&, seconds)
+		wait: func ~timed (seconds: Double) -> Bool {
+			version (apple || android) { return __fake_timedjoin(seconds) }
+			else {
+				ts: TimeSpec
+				__setupTimeout(ts&, seconds)
 
-            result := pthread_timedjoin_np(pthread, null, ts&)
-            return (result == 0)
-          }
-          false
-        }
+				result := pthread_timedjoin_np(pthread, null, ts&)
+				return (result == 0)
+			}
+			false
+		}
 
-        cancel: func -> Bool {
-          version (!android)
-            return this alive?() && (pthread_cancel(this pthread) == 0)
-          false
-        }
+		cancel: func -> Bool {
+			version (!android)
+				return this alive?() && (pthread_cancel(this pthread) == 0)
+			false
+		}
 
-        alive?: func -> Bool {
-            pthread_kill(pthread, 0) == 0
-        }
+		alive?: func -> Bool {
+			pthread_kill(pthread, 0) == 0
+		}
 
-        _currentThread: static func -> This {
-            thread := This new(func {})
-            thread pthread = pthread_self()
-            thread
-        }
+		_currentThread: static func -> This {
+			thread := This new(func {})
+			thread pthread = pthread_self()
+			thread
+		}
 
-        _yield: static func -> Bool {
-            // pthread_yield is non-standard, use sched_yield instead
-            // as a bonus, this works on OSX too.
-            result := sched_yield()
-            (result == 0)
-        }
+		_yield: static func -> Bool {
+			// pthread_yield is non-standard, use sched_yield instead
+			// as a bonus, this works on OSX too.
+			result := sched_yield()
+			(result == 0)
+		}
 
-        // private stuff
+		// private stuff
 
-        __setupTimeout: func (ts: TimeSpec@, seconds: Double) {
-            // We need an absolute number of seconds since the epoch
-            // First order of business - what time is it?
-            tv: TimeVal
-            gettimeofday(tv&, null)
+		__setupTimeout: func (ts: TimeSpec@, seconds: Double) {
+			// We need an absolute number of seconds since the epoch
+			// First order of business - what time is it?
+			tv: TimeVal
+			gettimeofday(tv&, null)
 
-            nowSeconds: Double = tv tv_sec as Double + tv tv_usec as Double / 1_000_000.0
+			nowSeconds: Double = tv tv_sec as Double + tv tv_usec as Double / 1_000_000.0
 
-            // Now compute the amount of seconds between January 1st, 1970 and the time
-            // we will stop waiting on our thread
-            absSeconds: Double = nowSeconds + seconds
+			// Now compute the amount of seconds between January 1st, 1970 and the time
+			// we will stop waiting on our thread
+			absSeconds: Double = nowSeconds + seconds
 
-            // And store it in a timespec, converting again...
-            ts tv_sec = floor(absSeconds) as TimeT
-            ts tv_nsec = ((absSeconds - ts tv_sec) * 1000 + 0.5) * (1_000_000 as Long)
-        }
+			// And store it in a timespec, converting again...
+			ts tv_sec = floor(absSeconds) as TimeT
+			ts tv_nsec = ((absSeconds - ts tv_sec) * 1000 + 0.5) * (1_000_000 as Long)
+		}
 
-        /*
-         * This is a semi-busywait implementation of timedjoin
-         * The real solution is to use condition variables, but
-         * I honestly don't have the courage to use them right now.
-         */
-        __fake_timedjoin: func (seconds: Double) -> Bool {
-            while (seconds > 0.0) {
-                Time sleepMilli(20)
-                seconds -= 0.02
-                if (!alive?()) {
-                    // successfully joined
-                    return true
-                }
-            }
-            false
-        }
+		/*
+		 * This is a semi-busywait implementation of timedjoin
+		 * The real solution is to use condition variables, but
+		 * I honestly don't have the courage to use them right now.
+		 */
+		__fake_timedjoin: func (seconds: Double) -> Bool {
+			while (seconds > 0.0) {
+				Time sleepMilli(20)
+				seconds -= 0.02
+				if (!alive?()) {
+					// successfully joined
+					return true
+				}
+			}
+			false
+		}
 
-    }
+	}
 
-    /* C interface */
-    include pthread
-    include sched
+	/* C interface */
+	include pthread
+	include sched
 
-    PThread: cover from pthread_t
-    TimeT: cover from time_t
-    TimeSpec: cover from struct timespec {
-        tv_sec: extern TimeT
-        tv_nsec: extern Long
-    }
+	PThread: cover from pthread_t
+	TimeT: cover from time_t
+	TimeSpec: cover from struct timespec {
+		tv_sec: extern TimeT
+		tv_nsec: extern Long
+	}
 
-    version (!apple && !android) {
-        // Using proto here as defining '_GNU_SOURCE' seems to cause more trouble than anything else...
-        pthread_timedjoin_np: extern proto func (thread: PThread, retval: Pointer, abstime: TimeSpec*) -> Int
-    }
+	version (!apple && !android) {
+		// Using proto here as defining '_GNU_SOURCE' seems to cause more trouble than anything else...
+		pthread_timedjoin_np: extern proto func (thread: PThread, retval: Pointer, abstime: TimeSpec*) -> Int
+	}
 
-    version(gc) {
-        pthread_create: extern(GC_pthread_create) func (threadPtr: PThread*, attrPtr: Pointer, startRoutine: Pointer, userArgument: Pointer) -> Int
-        pthread_join:   extern(GC_pthread_join)   func (thread: PThread, retval: Pointer*) -> Int
-    }
-    version (!gc) {
-        pthread_create: extern func (threadPtr: PThread*, attrPtr: Pointer, startRoutine: Pointer, userArgument: Pointer) -> Int
-        pthread_join:   extern func (thread: PThread, retval: Pointer*) -> Int
-    }
-    pthread_kill: extern func (thread: PThread, signal: Int) -> Int
-    pthread_self: extern func -> PThread
-    pthread_cancel: extern func (thread: PThread) -> Int
-    sched_yield: extern func -> Int
+	version (gc) {
+		pthread_create: extern (GC_pthread_create) func (threadPtr: PThread*, attrPtr: Pointer, startRoutine: Pointer, userArgument: Pointer) -> Int
+		pthread_join: extern (GC_pthread_join) func (thread: PThread, retval: Pointer*) -> Int
+	}
+	version (!gc) {
+		pthread_create: extern func (threadPtr: PThread*, attrPtr: Pointer, startRoutine: Pointer, userArgument: Pointer) -> Int
+		pthread_join: extern func (thread: PThread, retval: Pointer*) -> Int
+	}
+	pthread_kill: extern func (thread: PThread, signal: Int) -> Int
+	pthread_self: extern func -> PThread
+	pthread_cancel: extern func (thread: PThread) -> Int
+	sched_yield: extern func -> Int
 }

--- a/source/sdk/threading/native/ThreadWin32.ooc
+++ b/source/sdk/threading/native/ThreadWin32.ooc
@@ -3,100 +3,100 @@ import native/win32/[types, errors]
 
 version(windows) {
 
-    /**
-     * Win32 implementation of threads.
-     */
-    ThreadWin32: class extends Thread {
+	/**
+	 * Win32 implementation of threads.
+	 */
+	ThreadWin32: class extends Thread {
 
-        handle: Handle
-        threadID: UInt
+		handle: Handle
+		threadID: UInt
 
-        init: func ~win (=_code) {}
+		init: func ~win (=_code)
 
-        start: func -> Bool {
-            handle = _beginthreadex(
-                null,                    // default security attributes
-                0,                       // default stack size
-                _code as Closure thunk,  // thread start address
-                _code as Closure context,// argument to thread function
-                0,                       // start thread as soon as it is created
-                threadID&) as Handle     // returns the thread identifier
+		start: func -> Bool {
+			handle = _beginthreadex(
+				null,					// default security attributes
+				0,						// default stack size
+				_code as Closure thunk, // thread start address
+				_code as Closure context,// argument to thread function
+				0,						// start thread as soon as it is created
+				threadID&) as Handle	// returns the thread identifier
 
-            handle != INVALID_HANDLE_VALUE
-        }
+			handle != INVALID_HANDLE_VALUE
+		}
 
-        wait: func -> Bool {
-            result := WaitForSingleObject(handle, INFINITE)
-            result == WAIT_OBJECT_0
-        }
+		wait: func -> Bool {
+			result := WaitForSingleObject(handle, INFINITE)
+			result == WAIT_OBJECT_0
+		}
 
-        wait: func ~timed (seconds: Double) -> Bool {
-            millis := (seconds * 1000.0 + 0.5) as Long
-            result := WaitForSingleObject(handle, millis)
+		wait: func ~timed (seconds: Double) -> Bool {
+			millis := (seconds * 1000.0 + 0.5) as Long
+			result := WaitForSingleObject(handle, millis)
 
-            match result {
-              case WAIT_TIMEOUT =>
-                false // still running
-              case WAIT_OBJECT_0 =>
-                true // has exited!
-              case =>
-                // couldn't wait
-                Exception new(This, "wait~timed failed with %ld" format(result as Long)) throw()
-                false
-            }
-        }
+			match result {
+				case WAIT_TIMEOUT =>
+					false // still running
+				case WAIT_OBJECT_0 =>
+					true // has exited!
+				case =>
+					// couldn't wait
+					Exception new(This, "wait~timed failed with %ld" format(result as Long)) throw()
+					false
+			}
+		}
 
-        cancel: func -> Bool {
-            false
-            //this alive?() && TerminateThread(this handle, 0)
-            //TODO Find a better way to terminate Win32 threads, if any 
-        }
+		cancel: func -> Bool {
+			false
+			//this alive?() && TerminateThread(this handle, 0)
+			//TODO Find a better way to terminate Win32 threads, if any
+		}
 
-        alive?: func -> Bool {
-            result := WaitForSingleObject(handle, 0)
+		alive?: func -> Bool {
+			result := WaitForSingleObject(handle, 0)
 
-            // if it's equal, it has terminated, otherwise, it's still alive
-            result != WAIT_OBJECT_0
-        }
+			// if it's equal, it has terminated, otherwise, it's still alive
+			result != WAIT_OBJECT_0
+		}
 
-        _currentThread: static func -> This {
-            thread := This new(func {})
-            thread handle = GetCurrentThread()
-            thread
-        }
+		_currentThread: static func -> This {
+			thread := This new(func {})
+			thread handle = GetCurrentThread()
+			thread
+		}
 
-        _yield: static func -> Bool {
-            // I secretly curse whoever thought of this function name
-            SwitchToThread()
-        }
+		_yield: static func -> Bool {
+			// I secretly curse whoever thought of this function name
+			SwitchToThread()
+		}
 
-    }
+	}
 
-    /* C interface */
+	/* C interface */
 
-    include windows
+	include windows
 
-    // CreateThread causes memory leaks, see:
-    // http://stackoverflow.com/questions/331536/, and
-    // http://support.microsoft.com/kb/104641/en-us
-    // CreateThread: extern func (...) -> Handle
+	// CreateThread causes memory leaks, see:
+	// http://stackoverflow.com/questions/331536/, and
+	// http://support.microsoft.com/kb/104641/en-us
+	// CreateThread: extern func (...) -> Handle
 
-    version (gc) {
-      // Use Boehm-provided replacement for _beginthreadex
-      _beginthreadex: extern(GC_beginthreadex) func (security: Pointer, stackSize: UInt, startAddress: Pointer, arglist: Pointer, initflag: UInt, thrdaddr: UInt*) -> Handle
-    }
+	version (gc) {
+		// Use Boehm-provided replacement for _beginthreadex
+		_beginthreadex: extern (GC_beginthreadex) func (security: Pointer, stackSize: UInt, startAddress: Pointer, arglist: Pointer, initflag: UInt, thrdaddr: UInt*) -> Handle
+	}
 
-    version (!gc) {
-      _beginthreadex: extern func (security: Pointer, stackSize: UInt, startAddress: Pointer, arglist: Pointer, initflag: UInt, thrdaddr: UInt*) -> Handle
-    }
+	version (!gc) {
+		_beginthreadex: extern func (security: Pointer, stackSize: UInt, startAddress: Pointer, arglist: Pointer, initflag: UInt, thrdaddr: UInt*) -> Handle
+	}
 
-    GetCurrentThread: extern func -> Handle
-    WaitForSingleObject: extern func (...) -> Long
-    SwitchToThread: extern func -> Bool
-    TerminateThread: extern func (...) -> Bool
+	GetCurrentThread: extern func -> Handle
+	WaitForSingleObject: extern func (...) -> Long
+	SwitchToThread: extern func -> Bool
+	TerminateThread: extern func (...) -> Bool
 
-    INFINITE: extern Long
-    WAIT_OBJECT_0: extern Long
-    WAIT_TIMEOUT: extern Long
+	INFINITE: extern Long
+	WAIT_OBJECT_0: extern Long
+	WAIT_TIMEOUT: extern Long
 
 }


### PR DESCRIPTION
Again, append `?w=1`, there isn't really any change at all. Just want to get the whitespace fixes out of the way first, to make it easier for you.

Part of the work on #659 