### PR TITLE
Cleanup global namespace in System.ooc

### DIFF
--- a/source/sdk/os/System.ooc
+++ b/source/sdk/os/System.ooc
@@ -36,9 +36,6 @@ version(linux || apple) {
     _SC_NPROCESSORS_ONLN: extern Int
 }
 
-// for backwards compatibility, please use the namespaced version instead
-numProcessors: func -> Int { System numProcessors() }
-
 System: class {
 
     numProcessors: static func -> Int {


### PR DESCRIPTION
Removed a function from the global namespace that's deprecated and not used.