### PR TITLE
Calculate vector mean using given list of indices

### DIFF
--- a/source/math/FloatPoint2DVectorList.ooc
+++ b/source/math/FloatPoint2DVectorList.ooc
@@ -69,6 +69,23 @@ FloatPoint2DVectorList: class extends VectorList<FloatPoint2D> {
 		sortedY free()
 		result
 	}
+	getMean: func (indices: VectorList<Int>) -> FloatPoint2D {
+		result := FloatPoint2D new()
+		indicesCount := indices count
+		if (indicesCount > 0) {
+			buffer := this pointer as FloatPoint2D*
+			indicesBuffer := indices pointer as Int*
+			for (i in 0 .. indicesCount) {
+				index := indicesBuffer[i]
+				element := buffer[index]
+				result x = result x + element x
+				result y = result y + element y
+			}
+			result x = result x / indicesCount
+			result y = result y / indicesCount
+		}
+		result
+	}
 	operator + (value: FloatPoint2D) -> This {
 		result := This new()
 		for (i in 0 .. this _count)


### PR DESCRIPTION
Used to avoid the need of creating temporary vector just to calculate the mean for given vector subset.
Labelled with `performance` as it is used to optimize something in other project.