### PR TITLE
Added Text trim() and test in preparation for #643

### DIFF
--- a/source/base/Text.ooc
+++ b/source/base/Text.ooc
@@ -135,10 +135,15 @@ Text: cover {
 		this _buffer free(criteria)
 	}
 	slice: func (start, distance: Int) -> This {
-		result := This new(this _buffer slice(start, distance))
-		if (this _buffer owner == Owner Receiver)
-			result = result copy() // TODO: Could we be smarter here?
-		this free(Owner Receiver)
+		result: This
+		if (start == 0 && distance == this count)
+			result = this
+		else {
+			result = This new(this _buffer slice(start, distance))
+			if (this _buffer owner == Owner Receiver)
+				result = result copy() // TODO: Could we be smarter here?
+			this free(Owner Receiver)
+		}
 		result
 	}
 	split: func ~character (separator: Char) -> VectorList<This> {

--- a/source/base/Text.ooc
+++ b/source/base/Text.ooc
@@ -169,6 +169,16 @@ Text: cover {
 		separator free(Owner Receiver)
 		result
 	}
+	trim: func -> This {
+		length := this count
+		leftPosition := 0
+		rightPosition := length - 1
+		while (leftPosition < length && this _buffer[leftPosition] whitespace?())
+			++leftPosition
+		while (rightPosition > leftPosition && this _buffer[rightPosition] whitespace?())
+			--rightPosition
+		this slice(leftPosition, rightPosition - leftPosition + 1)
+	}
 	toString: func -> String {
 		result := String new(this _buffer raw, this count)
 		this free(Owner Receiver)

--- a/source/base/Text.ooc
+++ b/source/base/Text.ooc
@@ -135,15 +135,10 @@ Text: cover {
 		this _buffer free(criteria)
 	}
 	slice: func (start, distance: Int) -> This {
-		result: This
-		if (start == 0 && distance == this count)
-			result = this
-		else {
-			result = This new(this _buffer slice(start, distance))
-			if (this _buffer owner == Owner Receiver)
-				result = result copy() // TODO: Could we be smarter here?
-			this free(Owner Receiver)
-		}
+		result := This new(this _buffer slice(start, distance))
+		if (this _buffer owner == Owner Receiver)
+			result = result copy() // TODO: Could we be smarter here?
+		this free(Owner Receiver)
 		result
 	}
 	split: func ~character (separator: Char) -> VectorList<This> {

--- a/source/base/Text.ooc
+++ b/source/base/Text.ooc
@@ -170,10 +170,9 @@ Text: cover {
 		result
 	}
 	trim: func -> This {
-		length := this count
 		leftPosition := 0
-		rightPosition := length - 1
-		while (leftPosition < length && this _buffer[leftPosition] whitespace?())
+		rightPosition := this count - 1
+		while (leftPosition < this count && this _buffer[leftPosition] whitespace?())
 			++leftPosition
 		while (rightPosition > leftPosition && this _buffer[rightPosition] whitespace?())
 			--rightPosition

--- a/test/base/TextTest.ooc
+++ b/test/base/TextTest.ooc
@@ -166,6 +166,13 @@ TextTest: class extends Fixture {
 			text free()
 			text2 free()
 		})
+		this add("trim", func {
+			paddedText := t"  \t test \n test \r\n\t "
+			trimmedText := paddedText trim()
+			expect(trimmedText, is equal to(t"test \n test"))
+			paddedText free()
+			trimmedText free()
+		})
 	}
 }
 

--- a/test/base/TextTest.ooc
+++ b/test/base/TextTest.ooc
@@ -170,8 +170,6 @@ TextTest: class extends Fixture {
 			paddedText := t"  \t test \n test \r\n\t "
 			trimmedText := paddedText trim()
 			expect(trimmedText == t"test \n test")
-			paddedText free()
-			trimmedText free()
 		})
 	}
 }

--- a/test/base/TextTest.ooc
+++ b/test/base/TextTest.ooc
@@ -169,7 +169,7 @@ TextTest: class extends Fixture {
 		this add("trim", func {
 			paddedText := t"  \t test \n test \r\n\t "
 			trimmedText := paddedText trim()
-			expect(trimmedText, is equal to(t"test \n test"))
+			expect(trimmedText == t"test \n test")
 			paddedText free()
 			trimmedText free()
 		})


### PR DESCRIPTION
Motivation: #643 
* added ```Text trim()``` and associated test
* ~~added guard in ```slice()``` to prevent unnecessary slicing if the resulting slice would be an identical copy~~

```trim()``` could be implemented using only one loop (attacking both left and right), but that would mean less readable code and the performance gain is only really noticeable for very large strings where the non-whitespace characters are near center (I did a comparison a while back).

I'm tagging this as 'not ready' until we decide what to do here.