### PR TITLE
Moved getStandardEquals() to a separate file

### DIFF
--- a/source/sdk/lang/equalities.ooc
+++ b/source/sdk/lang/equalities.ooc
@@ -1,8 +1,6 @@
 // The following functions were moved from HashMap.ooc
 
-/* this function seem is called by List */
 getStandardEquals: func <T> (T: Class) -> Func <T> (T, T) -> Bool {
-    // choose comparing function for key type
     if(T == String) {
         stringEquals
     } else if(T == CString) {
@@ -26,7 +24,6 @@ stringEquals: func <K> (k1, k2: K) -> Bool {
 cstringEquals: func <K> (k1, k2: K) -> Bool {
     k1 as CString == k2 as CString
 }
-
 
 pointerEquals: func <K> (k1, k2: K) -> Bool {
     k1 as Pointer == k2 as Pointer

--- a/source/sdk/lang/equalities.ooc
+++ b/source/sdk/lang/equalities.ooc
@@ -1,0 +1,47 @@
+// The following functions were moved from HashMap.ooc
+
+/* this function seem is called by List */
+getStandardEquals: func <T> (T: Class) -> Func <T> (T, T) -> Bool {
+    // choose comparing function for key type
+    if(T == String) {
+        stringEquals
+    } else if(T == CString) {
+        cstringEquals
+    } else if(T size == Pointer size) {
+        pointerEquals
+    } else if(T size == UInt size) {
+        intEquals
+    } else if(T size == Char size) {
+        charEquals
+    } else {
+        genericEquals
+    }
+}
+
+stringEquals: func <K> (k1, k2: K) -> Bool {
+    assert(K == String)
+    k1 as String equals?(k2 as String)
+}
+
+cstringEquals: func <K> (k1, k2: K) -> Bool {
+    k1 as CString == k2 as CString
+}
+
+
+pointerEquals: func <K> (k1, k2: K) -> Bool {
+    k1 as Pointer == k2 as Pointer
+}
+
+intEquals: func <K> (k1, k2: K) -> Bool {
+    k1 as Int == k2 as Int
+}
+
+charEquals: func <K> (k1, k2: K) -> Bool {
+    k1 as Char == k2 as Char
+}
+
+/** used when we don't have a custom comparing function for the key type */
+genericEquals: func <K> (k1, k2: K) -> Bool {
+    // FIXME rock should turn == between generic vars into a memcmp itself
+    memcmp(k1, k2, K size) == 0
+}

--- a/source/sdk/structs/HashMap.ooc
+++ b/source/sdk/structs/HashMap.ooc
@@ -1,4 +1,4 @@
-
+import lang/equalities
 import ArrayList
 
 /**
@@ -17,34 +17,6 @@ HashEntry: cover {
 
 nullHashEntry: HashEntry
 memset(nullHashEntry&, 0, HashEntry size)
-
-stringEquals: func <K> (k1, k2: K) -> Bool {
-    assert(K == String)
-    k1 as String equals?(k2 as String)
-}
-
-cstringEquals: func <K> (k1, k2: K) -> Bool {
-    k1 as CString == k2 as CString
-}
-
-
-pointerEquals: func <K> (k1, k2: K) -> Bool {
-    k1 as Pointer == k2 as Pointer
-}
-
-intEquals: func <K> (k1, k2: K) -> Bool {
-    k1 as Int == k2 as Int
-}
-
-charEquals: func <K> (k1, k2: K) -> Bool {
-    k1 as Char == k2 as Char
-}
-
-/** used when we don't have a custom comparing function for the key type */
-genericEquals: func <K> (k1, k2: K) -> Bool {
-    // FIXME rock should turn == between generic vars into a memcmp itself
-    memcmp(k1, k2, K size) == 0
-}
 
 intHash: func <K> (key: K) -> SizeT {
     result: SizeT = key as Int
@@ -131,24 +103,6 @@ ac_X31_hash: func <K> (key: K) -> SizeT {
         }
     }
     return h
-}
-
-/* this function seem is called by List */
-getStandardEquals: func <T> (T: Class) -> Func <T> (T, T) -> Bool {
-    // choose comparing function for key type
-    if(T == String) {
-        stringEquals
-    } else if(T == CString) {
-        cstringEquals
-    } else if(T size == Pointer size) {
-        pointerEquals
-    } else if(T size == UInt size) {
-        intEquals
-    } else if(T size == Char size) {
-        charEquals
-    } else {
-        genericEquals
-    }
 }
 
 getStandardHashFunc: func <T> (T: Class) -> Func <T> (T) -> SizeT {

--- a/source/sdk/structs/List.ooc
+++ b/source/sdk/structs/List.ooc
@@ -1,4 +1,4 @@
-import structs/HashMap /* for getStandardEquals() - should probably move that in a separate Module */
+import lang/equalities
 
 /**
  * List interface for a data container


### PR DESCRIPTION
These functions didn't belong in `HashMap.ooc` as an original comment mentioned.

Furthermore, this (along with other sdk PRs here) allows us to move `Hash*` classes out of the sdk, meaning we can move `Cell` out of the sdk, meaning we can solve the problem with `is equal to(Text)` in `Fixture`.