### PR TITLE
Updated reference counter with safe/unsafe version

### DIFF
--- a/source/base/ReferenceCounter.ooc
+++ b/source/base/ReferenceCounter.ooc
@@ -1,20 +1,30 @@
 import threading/Thread
 import Synchronized
 
-ReferenceCounter: class extends Synchronized {
+ReferenceCounter: class {
 	_target: Object
 	count: static Int = 0
 	_count: Int = 0
 	_kill := false
-	init: func (target: Object) {
-		super()
+	_lock: Mutex
+	isSafe: Bool {
+		get { !this _lock instanceOf?(MutexUnsafe) }
+		set(value) {
+			if (this isSafe != value) {
+				this _lock free()
+				this _lock = Mutex new(value ? MutexType Safe : MutexType Unsafe)
+			}
+		}
+	}
+	init: func (target: Object, mutexType := MutexType Safe) {
 		This count += 1
 		this _target = target
+		this _lock = Mutex new(mutexType)
 //		"  RC, #{This count}, #{this _target class name}" println()
 	}
 	update: func (delta: Int) {
 		if (delta != 0) {
-			this lock()
+			this _lock lock()
 			target := null
 			if (!this _kill) {
 				this _count += delta
@@ -23,7 +33,7 @@ ReferenceCounter: class extends Synchronized {
 				if (this _kill)
 					target = this _target
 			}
-			this unlock()
+			this _lock unlock()
 			if (target != null) {
 				this _count = 0
 				this _kill = false
@@ -34,6 +44,7 @@ ReferenceCounter: class extends Synchronized {
 	free: override func {
 		This count -= 1
 //		"--RC, #{This count}, #{this _target class name}" println()
+		this _lock free()
 		super()
 	}
 	increase: func { this update(1) }

--- a/test/base/ReferenceCounterTest.ooc
+++ b/test/base/ReferenceCounterTest.ooc
@@ -34,6 +34,7 @@ ReferenceCounterTest: class extends Fixture {
 		isAlive: Bool
 		object := TestObject new(isAlive&)
 		counter := ReferenceCounter new(object)
+		counter isSafe = true
 		numberOfThreads := 8
 		countPerThread := 500
 		threads := Thread[numberOfThreads] new()


### PR DESCRIPTION
To change behaviour of existing ReferenceCounter:
`referenceCounter isSafe = true / false`
For now `safe` is default, as it was before.