### PR TITLE
Cleanup in Image interface, method to apply 2D transform to RasterBgr

### DIFF
--- a/source/draw/Image.ooc
+++ b/source/draw/Image.ooc
@@ -73,18 +73,18 @@ Image: abstract class {
 		this _canvas = null
 		super()
 	}
-	resizeWithin: func (restriction: IntSize2D) -> This {
-		this resizeTo(((this size toFloatSize2D()) * Float minimum(restriction width as Float / this size width as Float, restriction height as Float / this size height as Float)) toIntSize2D())
-	}
+	create: virtual func (size: IntSize2D) -> This { raise("Image type not implemented."); null }
+	copy: abstract func -> This
+	distance: virtual abstract func (other: This) -> Float
+	equals: func (other: This) -> Bool { this size == other size && this distance(other) < 10 * Float epsilon }
 	resizeTo: abstract func (size: IntSize2D) -> This
 	resizeTo: virtual func ~withMethod (size: IntSize2D, method: TransformMethod) -> This {
 		this resizeTo(size)
 	}
-	create: virtual func (size: IntSize2D) -> This { raise("Image type not implemented."); null }
-	copy: abstract func -> This
-	copy: abstract func ~fromParams (size: IntSize2D, transform: FloatTransform2D) -> This
-	distance: virtual abstract func (other: This) -> Float
-	equals: func (other: This) -> Bool { this size == other size && this distance(other) < 10 * Float epsilon }
+	transformed: virtual func (transform: FloatTransform2D, method := TransformMethod Smooth) -> This {
+		raise("transformed() not implemented!")
+		null
+	}
 	isValidIn: func (x, y: Int) -> Bool {
 		return (x >= 0 && x < this size width && y >= 0 && y < this size height)
 	}

--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -153,6 +153,26 @@ RasterBgr: class extends RasterPacked {
 		result swapRedBlue()
 		result
 	}
+	transformed: func (transform: FloatTransform2D, method := TransformMethod Smooth) -> This {
+		result: This
+		if (transform isIdentity)
+			result = this copy()
+		else {
+			inverse := transform inverse
+			box := FloatBox2D new(FloatPoint2D new(), this size toFloatSize2D())
+			topLeft := transform * box leftTop
+			topRight := transform * box rightTop
+			bottomLeft := transform * box leftBottom
+			bottomRight := transform * box rightBottom
+			result = This new(IntSize2D new(topLeft distance(topRight), topLeft distance(bottomLeft)))
+			for (row in 0 .. result height)
+				for (column in 0 .. result width) {
+					position := (inverse * FloatPoint2D new(column, row)) toIntPoint2D()
+					result[column, row] = this[position x, position y]
+				}
+		}
+		result
+	}
 	_createCanvas: override func -> Canvas { BgrRasterCanvas new(this) }
 	kean_draw_rasterBgr_new: static unmangled func (width, height, stride: Int, data: Void*) -> This {
 		result := This new(IntSize2D new(width, height), stride)

--- a/source/draw/RasterImage.ooc
+++ b/source/draw/RasterImage.ooc
@@ -38,26 +38,6 @@ RasterImage: abstract class extends Image {
 		result
 	}
 	copy: abstract func -> This
-	copy: func ~fromParams (size: IntSize2D, transform: FloatTransform2D) -> This {
-		transform = (this transform toFloatTransform2D()) * transform * (this transform toFloatTransform2D()) inverse
-		mappingTransform := FloatTransform2D createTranslation(this size width / 2, this size height / 2) * transform
-		upperLeft := mappingTransform * FloatPoint2D new(-size width / 2, -size width / 2)
-		upperRight := mappingTransform * FloatPoint2D new(size width / 2, -size width / 2)
-		downLeft := mappingTransform * FloatPoint2D new(-size width / 2, size width / 2)
-		downRight := mappingTransform * FloatPoint2D new(size width / 2, size width / 2)
-		source := FloatBox2D bounds([upperLeft, upperRight, downLeft, downRight])
-		mappingTransformInverse := mappingTransform inverse
-		upperLeft = mappingTransformInverse * source leftTop
-		upperRight = mappingTransformInverse * source rightTop
-		downLeft = mappingTransformInverse * source leftBottom
-		downRight = mappingTransformInverse * source rightBottom
-		this copy(size toFloatSize2D(), source, FloatPoint2D new(), FloatPoint2D new(), FloatPoint2D new())
-	}
-	copy: func ~fromMoreParams (size: FloatSize2D, source: FloatBox2D, upperLeft, upperRight, lowerLeft: FloatPoint2D) -> This {
-		result := RasterBgra new(size ceiling() toIntSize2D())
-//		TODO: The stuff
-		result
-	}
 	open: static func ~unknownType (filename: String) -> This {
 		x, y, imageComponents: Int
 		data := StbImage load(filename, x&, y&, imageComponents&, 0)

--- a/test/draw/RasterBgrTest.ooc
+++ b/test/draw/RasterBgrTest.ooc
@@ -63,6 +63,25 @@ RasterBgrTest: class extends Fixture {
 			image2 free()
 			output free()
 		})
+		this add("transformed", func {
+			outputScaled := "test/draw/output/RasterBgrTest_rescaled.png"
+			outputMirrored := "test/draw/output/RasterBgrTest_mirrored.png"
+			outputRotated := "test/draw/output/RasterBgrTest_rotated.png"
+			image := RasterBgr open(this sourceFlower)
+			result := image transformed(FloatTransform2D createScaling(0.55, 1.5))
+			result save(outputScaled)
+			result referenceCount decrease()
+			result = image transformed(FloatTransform2D createTranslation(image width / 2, image height / 2) * FloatTransform2D createReflectionY() * FloatTransform2D createTranslation(-image width / 2, -image height / 2))
+			result save(outputMirrored)
+			result referenceCount decrease()
+			result = image transformed(FloatTransform2D createTranslation(image width / 2, image height / 2) * FloatTransform2D createZRotation(3.14 / 4) * FloatTransform2D createTranslation(-image width / 2, -image height / 2))
+			result save(outputRotated)
+			result referenceCount decrease()
+			image referenceCount decrease()
+			outputMirrored free()
+			outputScaled free()
+			outputRotated free()
+		})
 	}
 }
 


### PR DESCRIPTION
Cleaned up unused functions from `Image` interface.
Added method to transform raster image with `FloatTransform2D` with test cases.