### PR TITLE
Fixed operator + in Event classes

### DIFF
--- a/source/base/Event.ooc
+++ b/source/base/Event.ooc
@@ -25,11 +25,16 @@ Event: class {
 	}
 	init: func (=_head)
 	init: func ~add (=_head, =_tail)
-	operator + (action: Func) -> This {
-		This new(action, this)
+	add: func (action: Func) -> This {
+		this add(This new(action, null))
 	}
-	operator + (event: This) -> This {
-		event != null ? This new(event _head, this) + event _tail : this
+	add: func ~withEvent (event: This) -> This {
+		if (event)
+			if (this _tail)
+				this _tail add(event)
+			else
+				this _tail = event
+		this
 	}
 	call: func {
 		if (this _tail != null)
@@ -54,22 +59,15 @@ Event1: class <T> {
 	init: func (=_head)
 	init: func ~add (=_head, =_tail)
 	add: func (action: Func(T)) -> This<T> {
-		This<T> new(action, this)
+		this add(This<T> new(action, null))
 	}
-	add: func ~event <T> (other: This<T>) -> This<T> {
-		if (other == null)
-			this
-		else
-			This<T> new(other _head, this) add(other _tail)
-	}
-	/* Does not work */
-	/*
-	operator + (action: Func(T)) -> This<T> {
-		This<T> new(action, this)
-	}
-	*/
-	operator + (event: This<T>) -> This<T> {
-		event != null ? This<T> new(event _head, this) + event _tail : this
+	add: func ~withEvent (event: This<T>) -> This<T> {
+		if (event)
+			if (this _tail)
+				this _tail add(event)
+			else
+				this _tail = event
+		this
 	}
 	call: func (argument: T) {
 		if (this _tail != null)
@@ -95,22 +93,15 @@ Event2: class <T0, T1> { // TODO: Write tests and fix this
 	init: func (=_head)
 	init: func ~add (=_head, =_tail)
 	add: func (action: Func(T0, T1)) -> This<T0, T1> {
-		This<T0, T1> new(action, this)
+		this add(This<T0, T1> new(action, null))
 	}
-	add: func ~event <T0, T1> (other: This<T0, T1>) -> This<T0, T1> {
-		if (other == null)
-			this
-		else
-			This<T0, T1> new(other _head, this) add(other _tail)
-	}
-	/* Does not work */
-	/*
-	operator + (action: Func(T0, T1)) -> This<T0, T1> {
-		Event2 new(action, this)
-	}
-	*/
-	operator + (event: This<T0, T1>) -> This<T0, T1> {
-		event != null ? This new(event _head, this) + event _tail : this
+	add: func ~withEvent (event: This<T0, T1>) -> This<T0, T1> {
+		if (event)
+			if (this _tail)
+				this _tail add(event)
+			else
+				this _tail = event
+		this
 	}
 	call: func (argument0: T0, argument1: T1) {
 		if (this _tail != null)

--- a/test/base/EventTest.ooc
+++ b/test/base/EventTest.ooc
@@ -29,13 +29,13 @@ EventTest: class extends Fixture {
 			counter0 := 0
 			counter1 := 0
 			e := Event new()
-			e += Event new(func { counter0 += 1 })
+			e add(Event new(func { counter0 += 1 }))
 			expect(counter0, is equal to(0))
 			expect(counter1, is equal to(0))
 			e call()
 			expect(counter0, is equal to(1))
 			expect(counter1, is equal to(0))
-			e += (func { counter1 += 1 })
+			e add(func { counter1 += 1 })
 			e call()
 			expect(counter0, is equal to(2))
 			expect(counter1, is equal to(1))
@@ -45,7 +45,7 @@ EventTest: class extends Fixture {
 			counter1 := 0
 			counter2 := 0
 			e := Event1<Int> new()
-			e += Event1<Int> new(func (delta: Int) { counter0 += delta })
+			e add(Event1<Int> new(func (delta: Int) { counter0 += delta }))
 			expect(counter0, is equal to(0))
 			expect(counter1, is equal to(0))
 			expect(counter2, is equal to(0))
@@ -53,7 +53,7 @@ EventTest: class extends Fixture {
 			expect(counter0, is equal to(1))
 			expect(counter1, is equal to(0))
 			expect(counter2, is equal to(0))
-			e += (Event1<Int> new(func (delta: Int) { counter1 += delta }))
+			e add(Event1<Int> new(func (delta: Int) { counter1 += delta }))
 			e call(1)
 			expect(counter0, is equal to(2))
 			expect(counter1, is equal to(1))
@@ -62,9 +62,7 @@ EventTest: class extends Fixture {
 			expect(counter0, is equal to(1339))
 			expect(counter1, is equal to(1338))
 			expect(counter2, is equal to(0))
-			/* Not working */
-			//e += (func (delta: Int) {	delta toString() println(); counter2 += delta	})
-			e = e add(func (delta: Int) { counter2 += delta })
+			e add(func (delta: Int) { counter2 += delta })
 			e call(-1337)
 			expect(counter0, is equal to(2))
 			expect(counter1, is equal to(1))
@@ -82,7 +80,7 @@ EventTest: class extends Fixture {
 			string1 := ""
 			string2 := ""
 			e := Event2<Int, String> new()
-			e += Event2<Int, String> new(func (delta: Int, s: String) { counter0 += delta; string0 += s })
+			e add(Event2<Int, String> new(func (delta: Int, s: String) { counter0 += delta; string0 += s }))
 			expect(counter0, is equal to(0))
 			expect(counter1, is equal to(0))
 			expect(counter2, is equal to(0))
@@ -96,7 +94,7 @@ EventTest: class extends Fixture {
 			expect(string0, is equal to("a"))
 			expect(string1, is equal to(""))
 			expect(string2, is equal to(""))
-			e += (Event2<Int, String> new(func (delta: Int, s: String) { counter1 += delta; string1 += s }))
+			e add(Event2<Int, String> new(func (delta: Int, s: String) { counter1 += delta; string1 += s }))
 			e call(1, "b")
 			expect(counter0, is equal to(2))
 			expect(counter1, is equal to(1))
@@ -111,9 +109,7 @@ EventTest: class extends Fixture {
 			expect(string0, is equal to("abc"))
 			expect(string1, is equal to("bc"))
 			expect(string2, is equal to(""))
-			/* Not working */
-			//e += (func (delta: Int, s: String) { counter2 += delta; string2 += s})
-			e = e add(func (delta: Int, s: String) { counter2 += delta; string2 += s })
+			e add(func (delta: Int, s: String) { counter2 += delta; string2 += s })
 			e call(-1337, "d")
 			expect(counter0, is equal to(2))
 			expect(counter1, is equal to(1))


### PR DESCRIPTION
Fixes problem with `operator +` mentioned here https://github.com/cogneco/ooc-kean/issues/755
Removed `add` functions as they duplicated the functionality of `operator +`
