### PR TITLE
Removed opengl=>ui dependency

### DIFF
--- a/source/draw/gpu/opengl/OpenGLContext.ooc
+++ b/source/draw/gpu/opengl/OpenGLContext.ooc
@@ -18,7 +18,6 @@ use ooc-math
 use ooc-draw
 use ooc-draw-gpu
 use ooc-collections
-use ooc-ui
 import OpenGLPacked, OpenGLMonochrome, OpenGLBgr, OpenGLBgra, OpenGLUv, OpenGLFence, OpenGLMesh, OpenGLCanvas, RecycleBin
 import OpenGLMap
 import backend/[GLContext, GLRenderer]
@@ -52,7 +51,7 @@ OpenGLContext: class extends GpuContext {
 	}
 	init: func { this init(GLContext createContext()) }
 	init: func ~shared (other: This) { this init(GLContext createContext(other _backend)) }
-	init: func ~window (nativeWindow: NativeWindow) { this init(GLContext createContext(nativeWindow)) }
+	init: func ~window (display: Pointer, nativeBackend: Long) { this init(GLContext createContext(display, nativeBackend)) }
 	free: override func {
 		this _backend makeCurrent()
 		this _transformTextureMap free()

--- a/source/draw/gpu/opengl/OpenGLWindow.ooc
+++ b/source/draw/gpu/opengl/OpenGLWindow.ooc
@@ -19,15 +19,14 @@ use ooc-draw
 use ooc-draw-gpu
 use ooc-opengl
 use ooc-base
-use ooc-ui
 
 version(!gpuOff) {
 OpenGLWindow: class extends OpenGLSurface {
 	_monochromeToBgra: OpenGLMap
 	_yuvSemiplanarToBgra: OpenGLMapTransform
-	init: func (native: NativeWindow) {
-		context := OpenGLContext new(native)
-		super(native size, context, OpenGLMap new(slurp("shaders/texture.frag"), context), IntTransform2D createScaling(1, -1))
+	init: func (windowSize: IntSize2D, display: Pointer, nativeBackend: Long) {
+		context := OpenGLContext new(display, nativeBackend)
+		super(windowSize, context, OpenGLMap new(slurp("shaders/texture.frag"), context), IntTransform2D createScaling(1, -1))
 		this _monochromeToBgra = OpenGLMap new(slurp("shaders/monochromeToBgra.frag"), context)
 		this _yuvSemiplanarToBgra = OpenGLMapTransform new(slurp("shaders/yuvSemiplanarToBgra.frag"), context)
 	}

--- a/source/draw/gpu/opengl/backend/GLContext.ooc
+++ b/source/draw/gpu/opengl/backend/GLContext.ooc
@@ -17,7 +17,6 @@
 
 use ooc-base
 use ooc-math
-use ooc-ui
 import gles3/Gles3Context
 import GLQuad, GLShaderProgram, GLTexture, GLFramebufferObject, GLFence, GLVolumeTexture, GLRenderer, GLVertexArrayObject
 
@@ -39,9 +38,9 @@ GLContext: abstract class {
 	createVolumeTexture: abstract func (size: IntSize3D, pixels: UInt8*) -> GLVolumeTexture
 	createRenderer: abstract func -> GLRenderer
 	createVertexArrayObject: abstract func (vertices: FloatPoint3D[], textureCoordinates: FloatPoint2D[]) -> GLVertexArrayObject
-	createContext: static func ~shared (window: NativeWindow, sharedContext: This = null) -> This {
+	createContext: static func ~shared (display: Pointer, nativeBackend: Long, sharedContext: This = null) -> This {
 		// This function will check whether a context creation succeeded and if not try to create a context for another OpenGL version
-		Gles3Context create(window, sharedContext as Gles3Context)
+		Gles3Context create(display, nativeBackend, sharedContext as Gles3Context)
 	}
 	createContext: static func ~pbufferShared (sharedContext: This = null) -> This {
 		// This function will check whether a context creation succeeded and if not try to create a context for another OpenGL version

--- a/source/draw/gpu/opengl/backend/gles3/Gles3Context.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Context.ooc
@@ -18,7 +18,6 @@
 version(!gpuOff) {
 use ooc-base
 use ooc-math
-use ooc-ui
 import ../egl/egl
 import ../[GLContext, GLTexture, GLVertexArrayObject]
 import include/gles3
@@ -84,8 +83,8 @@ Gles3Context: class extends GLContext {
 				"WARNING: Using OpenGL ES 2" println()
 		}
 	}
-	_generate: func (window: NativeWindow, sharedContext: This) -> Bool {
-		this _eglDisplay = eglGetDisplay(window display)
+	_generate: func (display: Pointer, nativeBackend: Long, sharedContext: This) -> Bool {
+		this _eglDisplay = eglGetDisplay(display)
 		if (this _eglDisplay == null)
 			return false
 		eglInitialize(this _eglDisplay, null, null)
@@ -97,7 +96,7 @@ Gles3Context: class extends GLContext {
 			EGL_NONE] as Int*
 		chosenConfig: Pointer = this _chooseConfig(configAttribs)
 
-		this _eglSurface = eglCreateWindowSurface(this _eglDisplay, chosenConfig, window backend, null)
+		this _eglSurface = eglCreateWindowSurface(this _eglDisplay, chosenConfig, nativeBackend, null)
 		if (this _eglSurface == null)
 			return false
 
@@ -169,10 +168,10 @@ Gles3Context: class extends GLContext {
 		glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_COLOR)
 		version(debugGL) { validateEnd("Context blend~alphaMonochrome") }
 	}
-	create: static func ~shared (window: NativeWindow, sharedContext: This = null) -> This {
+	create: static func ~shared (display: Pointer, nativeBackend: Long, sharedContext: This = null) -> This {
 		version(debugGL) { Debug print("Creating OpenGL Context") }
 		result := This new()
-		result _generate(window, sharedContext) ? result : null
+		result _generate(display, nativeBackend, sharedContext) ? result : null
 	}
 	create: static func ~pbufferShared (sharedContext: This = null) -> This {
 		version(debugGL) { Debug print("Creating OpenGL Context") }

--- a/source/widgets/UnixWindow.ooc
+++ b/source/widgets/UnixWindow.ooc
@@ -57,7 +57,7 @@ UnixWindow: class extends UnixWindowBase {
 	context ::= this _openGLWindow context
 	init: func (size: IntSize2D, title: String) {
 		super(size, title)
-		this _openGLWindow = OpenGLWindow new(this _xWindow)
+		this _openGLWindow = OpenGLWindow new(this _xWindow size, this _xWindow display, this _xWindow backend)
 	}
 	free: override func {
 		this _openGLWindow free()


### PR DESCRIPTION
We need to remove `widgets` module (https://github.com/cogneco/ooc-kean/issues/813) and move everything from there into `ui` (and later rename to `gui`).
Currently it can't be done because `widgets` module depends on `opengl` and `opengl` depends on `ui` (so moving stuff from widgets into ui results in circular dependency `opengl <=> ui`).
This pull request removes the `opengl => ui` dependency and is the first step to remove `widgets` module.