### PR TITLE
Removed ~two suffix from Int minimum and maximum.

### DIFF
--- a/source/base/OwnedBuffer.ooc
+++ b/source/base/OwnedBuffer.ooc
@@ -67,7 +67,7 @@ OwnedBuffer: cover {
 			start = this _size + start
 		if (distance < 0)
 			start -= size
-		start < this size ? This new(this _pointer + start, Int minimum~two(size, this _size - start), Owner Unknown) : This empty
+		start < this size ? This new(this _pointer + start, Int minimum(size, this _size - start), Owner Unknown) : This empty
 	}
 	copy: func -> This { // call by value -> modifies copy of cover
 		result: This

--- a/source/base/Text.ooc
+++ b/source/base/Text.ooc
@@ -67,7 +67,7 @@ Text: cover {
 		this free(Owner Receiver)
 		This new(result)
 	}
-	beginsWith: func (other: This) -> Bool { this slice(0, Int minimum~two(other count, this count)) == other }
+	beginsWith: func (other: This) -> Bool { this slice(0, Int minimum(other count, this count)) == other }
 	beginsWith: func ~string (other: String) -> Bool { this beginsWith(This new(other)) }
 	beginsWith: func ~character (character: Char) -> Bool {
 		result := (this count > 0) && (this _buffer[0] == character)
@@ -75,7 +75,7 @@ Text: cover {
 		result
 	}
 	endsWith: func (other: This) -> Bool {
-		this slice(Int maximum~two(0, this count - other count), Int minimum~two(other count, this count)) == other
+		this slice(Int maximum(0, this count - other count), Int minimum(other count, this count)) == other
 	}
 	endsWith: func ~string (other: String) -> Bool { this endsWith(This new(other)) }
 	endsWith: func ~character (character: Char) -> Bool {

--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -77,8 +77,8 @@ RasterBgr: class extends RasterPacked {
 					if (c distance(o) > 0) {
 						maximum := o
 						minimum := o
-						for (otherY in Int maximum~two(0, y - this distanceRadius) .. Int minimum~two(y + 1 + this distanceRadius, this size height))
-							for (otherX in Int maximum~two(0, x - this distanceRadius) .. Int minimum~two(x + 1 + this distanceRadius, this size width))
+						for (otherY in Int maximum(0, y - this distanceRadius) .. Int minimum(y + 1 + this distanceRadius, this size height))
+							for (otherX in Int maximum(0, x - this distanceRadius) .. Int minimum(x + 1 + this distanceRadius, this size width))
 								if (otherX != x || otherY != y) {
 									pixel := (other as This)[otherX, otherY]
 									if (maximum blue < pixel blue)

--- a/source/draw/RasterBgra.ooc
+++ b/source/draw/RasterBgra.ooc
@@ -79,8 +79,8 @@ RasterBgra: class extends RasterPacked {
 					if (c distance(o) > 0) {
 						maximum := o
 						minimum := o
-						for (otherY in Int maximum~two(0, y - this distanceRadius) .. Int minimum~two(y + 1 + this distanceRadius, this size height))
-							for (otherX in Int maximum~two(0, x - this distanceRadius) .. Int minimum~two(x + 1 + this distanceRadius, this size width))
+						for (otherY in Int maximum(0, y - this distanceRadius) .. Int minimum(y + 1 + this distanceRadius, this size height))
+							for (otherX in Int maximum(0, x - this distanceRadius) .. Int minimum(x + 1 + this distanceRadius, this size width))
 								if (otherX != x || otherY != y) {
 									pixel := (other as This)[otherX, otherY]
 									if (maximum blue < pixel blue)

--- a/source/draw/RasterCanvas.ooc
+++ b/source/draw/RasterCanvas.ooc
@@ -33,21 +33,21 @@ RasterCanvas: abstract class extends Canvas {
 	}
 	_drawLine: func (start, end: IntPoint2D) {
 		if (start y == end y) {
-			startX := Int minimum~two(start x, end x)
-			endX := Int maximum~two(start x, end x)
+			startX := Int minimum(start x, end x)
+			endX := Int maximum(start x, end x)
 			for (x in startX .. endX + 1)
 				this _drawPoint(x, start y)
 		} else if (start x == end x) {
-			startY := Int minimum~two(start y, end y)
-			endY := Int maximum~two(start y, end y)
+			startY := Int minimum(start y, end y)
+			endY := Int maximum(start y, end y)
 			for (y in startY .. endY + 1)
 				this _drawPoint(start x, y)
 		} else {
 			originalPen := this pen
 			originalAlpha := originalPen alphaAsFloat
 			slope := (end y - start y) as Float / (end x - start x) as Float
-			startX := Int minimum~two(start x, end x)
-			endX := Int maximum~two(start x, end x)
+			startX := Int minimum(start x, end x)
+			endX := Int maximum(start x, end x)
 			for (x in startX .. endX + 1) {
 				idealY := slope * (x - start x) + start y
 				floor := idealY floor()

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -134,8 +134,8 @@ RasterMonochrome: class extends RasterPacked {
 					if (c distance(o) > 0) {
 						maximum := o
 						minimum := o
-						for (otherY in Int maximum~two(0, y - 2) .. Int minimum~two(y + 3, this size height))
-							for (otherX in Int maximum~two(0, x - 2) .. Int minimum~two(x + 3, this size width))
+						for (otherY in Int maximum(0, y - 2) .. Int minimum(y + 3, this size height))
+							for (otherX in Int maximum(0, x - 2) .. Int minimum(x + 3, this size width))
 								if (otherX != x || otherY != y) {
 									pixel := (other as This)[otherX, otherY]
 									if (maximum y < pixel y)

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -75,8 +75,8 @@ RasterUv: class extends RasterPacked {
 					if (c distance(o) > 0) {
 						maximum := o
 						minimum := o
-						for (otherY in Int maximum~two(0, y - this distanceRadius) .. Int minimum~two(y + 1 + this distanceRadius, this size height))
-							for (otherX in Int maximum~two(0, x - this distanceRadius) .. Int minimum~two(x + 1 + this distanceRadius, this size width))
+						for (otherY in Int maximum(0, y - this distanceRadius) .. Int minimum(y + 1 + this distanceRadius, this size height))
+							for (otherX in Int maximum(0, x - this distanceRadius) .. Int minimum(x + 1 + this distanceRadius, this size width))
 								if (otherX != x || otherY != y) {
 									pixel := (other as This)[otherX, otherY]
 									if (maximum u < pixel u)

--- a/source/draw/RasterYuvPlanar.ooc
+++ b/source/draw/RasterYuvPlanar.ooc
@@ -77,8 +77,8 @@ RasterYuvPlanar: abstract class extends RasterPlanar {
 					if (c distance(o) > 0) {
 						maximum := o
 						minimum := o
-						for (otherY in Int maximum~two(0, y - this distanceRadius) .. Int minimum~two(y + 1 + this distanceRadius, this size height))
-							for (otherX in Int maximum~two(0, x - this distanceRadius) .. Int minimum~two(x + 1 + this distanceRadius, this size width))
+						for (otherY in Int maximum(0, y - this distanceRadius) .. Int minimum(y + 1 + this distanceRadius, this size height))
+							for (otherX in Int maximum(0, x - this distanceRadius) .. Int minimum(x + 1 + this distanceRadius, this size width))
 								if (otherX != x || otherY != y) {
 									pixel := (other as This)[otherX, otherY]
 									if (maximum y < pixel y)

--- a/source/draw/RasterYuvSemiplanar.ooc
+++ b/source/draw/RasterYuvSemiplanar.ooc
@@ -78,8 +78,8 @@ RasterYuvSemiplanar: abstract class extends RasterPlanar {
 					if (c distance(o) > 0) {
 						maximum := o
 						minimum := o
-						for (otherY in Int maximum~two(0, y - this distanceRadius) .. Int minimum~two(y + 1 + this distanceRadius, this size height))
-							for (otherX in Int maximum~two(0, x - this distanceRadius) .. Int minimum~two(x + 1 + this distanceRadius, this size width))
+						for (otherY in Int maximum(0, y - this distanceRadius) .. Int minimum(y + 1 + this distanceRadius, this size height))
+							for (otherX in Int maximum(0, x - this distanceRadius) .. Int minimum(x + 1 + this distanceRadius, this size width))
 								if (otherX != x || otherY != y) {
 									pixel := (other as This)[otherX, otherY]
 									if (maximum y < pixel y)

--- a/source/math/FloatMatrix.ooc
+++ b/source/math/FloatMatrix.ooc
@@ -48,7 +48,7 @@ FloatMatrix : cover {
 		result
 	}}
 	order: Int { get {
-		result := Int minimum~two(this _dimensions height, this _dimensions width)
+		result := Int minimum(this _dimensions height, this _dimensions width)
 		this free(Owner Receiver)
 		result
 	}}

--- a/source/math/IntBox2D.ooc
+++ b/source/math/IntBox2D.ooc
@@ -47,8 +47,8 @@ IntBox2D: cover {
 	init: func@ ~fromInts (left, top, width, height: Int) { this init(IntPoint2D new(left, top), IntSize2D new(width, height)) }
 	//init: func@ ~fromSize (size: IntSize2D) { this init(IntPoint2D new(), size) }
 	init: func@ ~fromPoints (first, second: IntPoint2D) {
-		left := Int minimum~two(first x, second x)
-		top := Int minimum~two(first y, second y)
+		left := Int minimum(first x, second x)
+		top := Int minimum(first y, second y)
 		width := (first x - second x) abs()
 		height := (first y - second y) abs()
 		this init(left, top, width, height)
@@ -73,17 +73,17 @@ IntBox2D: cover {
 		This createAround(this center, IntSize2D minimum(this size, size))
 	}
 	intersection: func (other: This) -> This {
-		left := Int maximum~two(this left, other left)
-		top := Int maximum~two(this top, other top)
-		width := Int maximum~two(0, Int minimum~two(this right, other right) - left)
-		height := Int maximum~two(0, Int minimum~two(this bottom, other bottom) - top)
+		left := Int maximum(this left, other left)
+		top := Int maximum(this top, other top)
+		width := Int maximum(0, Int minimum(this right, other right) - left)
+		height := Int maximum(0, Int minimum(this bottom, other bottom) - top)
 		This new(left, top, width, height)
 	}
 	union: func ~box (other: This) -> This { // Rock bug: Union without suffix cannot be used because the C name conflicts with keyword "union"
-		left := Int minimum~two(this left, other left)
-		top := Int minimum~two(this top, other top)
-		width := Int maximum~two(0, Int maximum(this right, other right) - left)
-		height := Int maximum~two(0, Int maximum(this bottom, other bottom) - top)
+		left := Int minimum(this left, other left)
+		top := Int minimum(this top, other top)
+		width := Int maximum(0, Int maximum(this right, other right) - left)
+		height := Int maximum(0, Int maximum(this bottom, other bottom) - top)
 		This new(left, top, width, height)
 	}
 	union: func ~point (point: IntPoint2D) -> This {

--- a/source/math/IntPoint2D.ooc
+++ b/source/math/IntPoint2D.ooc
@@ -26,8 +26,8 @@ IntPoint2D: cover {
 	scalarProduct: func (other: This) -> Int { this x * other x + this y * other y }
 	swap: func -> This { This new(this y, this x) }
 	distance: func (other: This) -> Float { (this - other) toFloatPoint2D() norm }
-	minimum: func (ceiling: This) -> This { This new(Int minimum~two(this x, ceiling x), Int minimum~two(this y, ceiling y)) }
-	maximum: func (floor: This) -> This { This new(Int maximum~two(this x, floor x), Int maximum~two(this y, floor y)) }
+	minimum: func (ceiling: This) -> This { This new(Int minimum(this x, ceiling x), Int minimum(this y, ceiling y)) }
+	maximum: func (floor: This) -> This { This new(Int maximum(this x, floor x), Int maximum(this y, floor y)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y)) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y) }
 	operator + (other: IntSize2D) -> This { This new(this x + other width, this y + other height) }

--- a/source/math/IntPoint3D.ooc
+++ b/source/math/IntPoint3D.ooc
@@ -26,8 +26,8 @@ IntPoint3D: cover {
 	init: func@ ~default { this init(0, 0, 0) }
 	init: func@ ~fromPoint2D (point: IntPoint2D, z := 0) { this init(point x, point y, z) }
 	scalarProduct: func (other: This) -> Int { this x * other x + this y * other y + this z * other z }
-	minimum: func (ceiling: This) -> This { This new(Int minimum~two(this x, ceiling x), Int minimum~two(this y, ceiling y), Int minimum~two(this z, ceiling z)) }
-	maximum: func (floor: This) -> This { This new(Int maximum~two(this x, floor x), Int maximum~two(this y, floor y), Int maximum~two(this z, floor z)) }
+	minimum: func (ceiling: This) -> This { This new(Int minimum(this x, ceiling x), Int minimum(this y, ceiling y), Int minimum(this z, ceiling z)) }
+	maximum: func (floor: This) -> This { This new(Int maximum(this x, floor x), Int maximum(this y, floor y), Int maximum(this z, floor z)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y), this z clamp(floor z, ceiling z)) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y, this z + other z) }
 	operator + (other: IntSize3D) -> This { This new(this x + other width, this y + other height, this z + other depth) }

--- a/source/math/IntShell2D.ooc
+++ b/source/math/IntShell2D.ooc
@@ -43,10 +43,10 @@ IntShell2D: cover {
 	operator - (other: This) -> This { This new(this left - other left, this right - other right, this top - other top, this bottom - other bottom) }
 	operator / (other: Int) -> This { This new(this left / other, this right / other, this top / other, this bottom / other) }
 	maximum: func (other: This) -> This {
-		This new(Int maximum~two(this left, other left), Int maximum~two(this right, other right), Int maximum~two(this top, other top), Int maximum~two(this bottom, other bottom))
+		This new(Int maximum(this left, other left), Int maximum(this right, other right), Int maximum(this top, other top), Int maximum(this bottom, other bottom))
 	}
 	minimum: func (other: This) -> This {
-		This new(Int minimum~two(this left, other left), Int minimum~two(this right, other right), Int minimum~two(this top, other top), Int minimum~two(this bottom, other bottom))
+		This new(Int minimum(this left, other left), Int minimum(this right, other right), Int minimum(this top, other top), Int minimum(this bottom, other bottom))
 	}
 	operator == (other: This) -> Bool { this left == other left && this right == other right && this top == other top && this bottom == other bottom }
 	operator != (other: This) -> Bool { !(this == other) }

--- a/source/math/IntSize2D.ooc
+++ b/source/math/IntSize2D.ooc
@@ -31,8 +31,8 @@ IntSize2D: cover {
 	init: func@ ~default { this init(0, 0) }
 	scalarProduct: func (other: This) -> Int { this width * other width + this height * other height }
 	swap: func -> This { This new(this height, this width) }
-	minimum: func (ceiling: This) -> This { This new(Int minimum~two(this width, ceiling width), Int minimum~two(this height, ceiling height)) }
-	maximum: func (floor: This) -> This { This new(Int maximum~two(this width, floor width), Int maximum~two(this height, floor height)) }
+	minimum: func (ceiling: This) -> This { This new(Int minimum(this width, ceiling width), Int minimum(this height, ceiling height)) }
+	maximum: func (floor: This) -> This { This new(Int maximum(this width, floor width), Int maximum(this height, floor height)) }
 	minimum: func ~Int (ceiling: Int) -> This { this minimum(This new(ceiling)) }
 	maximum: func ~Int (floor: Int) -> This { this maximum(This new(floor)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this width clamp(floor width, ceiling width), this height clamp(floor height, ceiling height)) }

--- a/source/math/IntSize3D.ooc
+++ b/source/math/IntSize3D.ooc
@@ -29,8 +29,8 @@ IntSize3D: cover {
 	init: func@ (=width, =height, =depth)
 	init: func@ ~default { this init(0, 0, 0) }
 	scalarProduct: func (other: This) -> Int { this width * other width + this height * other height + this depth * other depth }
-	minimum: func (ceiling: This) -> This { This new(Int minimum~two(this width, ceiling width), Int minimum~two(this height, ceiling height), Int minimum~two(this depth, ceiling depth)) }
-	maximum: func (floor: This) -> This { This new(Int maximum~two(this width, floor width), Int maximum~two(this height, floor height), Int maximum~two(this depth, floor depth)) }
+	minimum: func (ceiling: This) -> This { This new(Int minimum(this width, ceiling width), Int minimum(this height, ceiling height), Int minimum(this depth, ceiling depth)) }
+	maximum: func (floor: This) -> This { This new(Int maximum(this width, floor width), Int maximum(this height, floor height), Int maximum(this depth, floor depth)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this width clamp(floor width, ceiling width), this height clamp(floor height, ceiling height), this depth clamp(floor depth, ceiling depth)) }
 	operator + (other: This) -> This { This new(this width + other width, this height + other height, this depth + other depth) }
 	operator + (other: IntPoint3D) -> This { This new(this width + other x, this height + other y, this depth + other z) }

--- a/source/sdk/math.ooc
+++ b/source/sdk/math.ooc
@@ -100,10 +100,10 @@ extend Int {
 	sign: static func (value: This) -> This {
 		value >= 0 ? 1 : -1
 	}
-	maximum: static func ~two (first: This, second: This) -> This {
+	maximum: static func (first: This, second: This) -> This {
 		first > second ? first : second
 	}
-	minimum: static func ~two (first: This, second: This) -> This {
+	minimum: static func (first: This, second: This) -> This {
 		first < second ? first : second
 	}
 	modulo: static func ~deprecated (dividend: This, divisor: This) -> This {


### PR DESCRIPTION
Fixes #821.
Removed all ~two suffixes from function calls and from the function signatures. 