### PR TITLE
Moved some operators from Text to TextBuffer

### DIFF
--- a/source/base/Text.ooc
+++ b/source/base/Text.ooc
@@ -49,13 +49,7 @@ Text: cover {
 	}
 	copyTo: func (buffer: TextBuffer) -> Int { this _buffer copyTo(buffer) }
 	operator == (string: String) -> Bool { this == This new(string) }
-	operator == (other: This) -> Bool {
-		result := this _buffer == other _buffer
-		if (this _buffer _backend pointer != other _buffer _backend pointer)
-			other free(Owner Receiver)
-		this free(Owner Receiver)
-		result
-	}
+	operator == (other: This) -> Bool { this _buffer == other _buffer }
 	operator != (other: String) -> Bool { !(this == other) }
 	operator != (other: This) -> Bool { !(this == other) }
 	operator + (other: This) -> This {

--- a/source/base/Text.ooc
+++ b/source/base/Text.ooc
@@ -52,15 +52,7 @@ Text: cover {
 	operator == (other: This) -> Bool { this _buffer == other _buffer }
 	operator != (other: String) -> Bool { !(this == other) }
 	operator != (other: This) -> Bool { !(this == other) }
-	operator + (other: This) -> This {
-		result := TextBuffer new(this take() count + other take() count)
-		this _buffer copyTo(result)
-		other _buffer copyTo(result slice(this take() count))
-		if (this _buffer _backend pointer != other _buffer _backend pointer)
-			other free(Owner Receiver)
-		this free(Owner Receiver)
-		This new(result)
-	}
+	operator + (other: This) -> This { This new(this _buffer + other _buffer) }
 	beginsWith: func (other: This) -> Bool { this slice(0, Int minimum(other count, this count)) == other }
 	beginsWith: func ~string (other: String) -> Bool { this beginsWith(This new(other)) }
 	beginsWith: func ~character (character: Char) -> Bool {

--- a/source/base/TextBuffer.ooc
+++ b/source/base/TextBuffer.ooc
@@ -91,5 +91,14 @@ TextBuffer: cover {
 		this free(Owner Receiver)
 		result
 	}
+	operator + (other: This) -> This {
+		result := This new(this take() count + other take() count)
+		this copyTo(result)
+		other copyTo(result slice(this take() count))
+		if (this _backend _pointer != other _backend _pointer)
+			other free(Owner Receiver)
+		this free(Owner Receiver)
+		result
+	}
 	empty: static This { get { This new() } }
 }

--- a/source/base/TextBuffer.ooc
+++ b/source/base/TextBuffer.ooc
@@ -84,6 +84,12 @@ TextBuffer: cover {
 	operator [] (range: Range) -> This { this slice(range min, range max - range min) }
 	operator []= (index: Int, value: Char) { this raw[index] = value }
 	operator []= (range: Range, data: This) { data copyTo(this[range]) }
-	operator == (other: This) -> Bool { this _backend == other _backend }
+	operator == (other: This) -> Bool {
+		result := this _backend == other _backend
+		if (this _backend _pointer != other _backend _pointer)
+			other free(Owner Receiver)
+		this free(Owner Receiver)
+		result
+	}
 	empty: static This { get { This new() } }
 }


### PR DESCRIPTION
@simonmika Is this what you had in mind? Do we generally want to move the logic and freeing from `Text` to `TextBuffer` when possible? Right now it seems to be a bit of a mix. Also, for example `count` in `Text` is basically a wrapper for `count` in `TextBuffer` but they both `free`. This seems to be redundant (and potentially also causing a double free, did not check).

Should point out also that I have not been following the discussion of `Text`/`TextBuffer` closely so I'm not sure exactly what we're trying to accomplish with these.