### PR TITLE
Removed public forceFree for ByteBuffer

### DIFF
--- a/source/base/ByteBuffer.ooc
+++ b/source/base/ByteBuffer.ooc
@@ -28,17 +28,17 @@ ByteBuffer: class {
 	size ::= this _size
 	_referenceCount: ReferenceCounter
 	referenceCount ::= this _referenceCount
-	_owner: Bool
+	_ownsMemory: Bool
 
-	init: func (=_pointer, =_size, owner := false) {
+	init: func (=_pointer, =_size, ownsMemory := false) {
 		this _referenceCount = ReferenceCounter new(this)
-		this _owner = owner
+		this _ownsMemory = ownsMemory
 	}
 	free: override func {
 		if (this _referenceCount != null)
 			this _referenceCount free()
 		this _referenceCount = null
-		if (this _owner)
+		if (this _ownsMemory)
 			gc_free(this _pointer)
 		this _pointer = null
 		super()

--- a/source/base/ByteBuffer.ooc
+++ b/source/base/ByteBuffer.ooc
@@ -65,7 +65,7 @@ ByteBuffer: class {
 		memcpy(other pointer + destination, this pointer + start, length)
 	}
 	new: static func ~size (size: Int) -> This { _RecyclableByteBuffer new(size) }
-	new: static func ~recover (pointer: UInt8*, size: Int, recover: Func (This)) -> This {
+	new: static func ~recover (pointer: UInt8*, size: Int, recover: Func (This) -> Bool) -> This {
 		_RecoverableByteBuffer new(pointer, size, recover)
 	}
 	clean: static func { _RecyclableByteBuffer _clean() }
@@ -85,12 +85,10 @@ _SlicedByteBuffer: class extends ByteBuffer {
 	}
 }
 _RecoverableByteBuffer: class extends ByteBuffer {
-	_recover: Func (ByteBuffer)
+	_recover: Func (ByteBuffer) -> Bool
 	init: func (pointer: UInt8*, size: Int, =_recover) { super(pointer, size) }
 	free: override func {
-		if (!this _forceFree)
-			this _recover(this)
-		else {
+		if (!this _recover(this)) {
 			(this _recover as Closure) dispose()
 			super()
 		}

--- a/source/draw/gpu/opengl/AndroidContext.ooc
+++ b/source/draw/gpu/opengl/AndroidContext.ooc
@@ -75,15 +75,14 @@ AndroidContext: class extends OpenGLContext {
 		fence := this createFence()
 		fence sync()
 		eglImage := gpuRgba as EGLBgra
-		sourcePointer := eglImage buffer lock(false)
+		sourcePointer := eglImage buffer lock(false) as UInt8*
 		length := channels * eglImage size width * eglImage size height
-		buffer := ByteBuffer new(sourcePointer, length,
-			func (b: ByteBuffer) {
-				eglImage buffer unlock()
-				this recyclePacker(gpuRgba)
-				b forceFree()
-			})
-		(buffer, fence)
+		recover := func (b: ByteBuffer) -> Bool {
+			eglImage buffer unlock()
+			this recyclePacker(gpuRgba)
+			false
+		}
+		(ByteBuffer new(sourcePointer, length, recover), fence)
 	}
 	toRaster: func ~monochrome (gpuImage: OpenGLMonochrome, async: Bool) -> RasterImage {
 		(buffer, fence) := this toBuffer(gpuImage, this _packMonochrome)

--- a/source/draw/gpu/opengl/GraphicBufferYuv420Semiplanar.ooc
+++ b/source/draw/gpu/opengl/GraphicBufferYuv420Semiplanar.ooc
@@ -35,8 +35,7 @@ GraphicBufferYuv420Semiplanar: class extends RasterYuv420Semiplanar {
 		ptr := _buffer lock()
 		_buffer unlock()
 		length := 3 * this _stride * size height / 2
-		byteBuffer := ByteBuffer new(ptr, length, func (buffer: ByteBuffer))
-		super(byteBuffer, size, _stride, _uvOffset)
+		super(ByteBuffer new(ptr, length), size, _stride, _uvOffset)
 	}
 	init: func (backend: Pointer, nativeBuffer: Pointer, handle: Pointer, size: IntSize2D, format: GraphicBufferFormat, stride: Int, uvOffset: Int) {
 		this init(GraphicBuffer new(backend, nativeBuffer, handle, size, stride, format), size, stride, uvOffset)


### PR DESCRIPTION
* In `_RecoverableByteBuffer` replaced `forceFree` by returning a `Bool` in the `recover` function which determines if the object shall be freed.
* In `_RecyclableByteBuffer` `forceFree` is now private and signaled when freeing and `this _size == 0`

Fixes https://github.com/cogneco/ooc-kean/issues/698