### PR TITLE
Added memcheck script for kean tests. No leak check for now, only inv…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ rock_tmp
 /test/*/output
 tests.use
 Tests
+*.valgrindlog

--- a/tools/memcheck.sh
+++ b/tools/memcheck.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+valgrind --log-file=memcheck.valgrindlog --suppressions=./kean.supp --num-callers=500 --time-stamp=yes ./Tests -n $@


### PR DESCRIPTION
…alid memory access. There are so many leaks from strings and other things in the tests that Atom crashes when scrolling around in the log (which has nearly 100,000 lines in it). It's a good thing to be able to test for invalid reads, though (and there were only a few of those, last time I checked).

The script will run `Tests` built by running `test.sh`. That means if you want to run memcheck for e.g. only the `Text` tests, you first call `test.sh base/Text`, then `memcheck.sh`. It would perhaps be nice to integrate with `test.sh` instead, so that you call `test.sh memcheck base/Text` or something.