### PR TITLE
Added squared distance between two FloatPoint2D's

### DIFF
--- a/source/math/FloatPoint2D.ooc
+++ b/source/math/FloatPoint2D.ooc
@@ -32,6 +32,10 @@ FloatPoint2D: cover {
 		(this scalarProduct(other) / (this norm * other norm)) clamp(-1, 1) acos() * (this x * other y - this y * other x < 0 ? -1 : 1)
 	}
 	distance: func (other: This) -> Float { (this - other) norm }
+	distanceSquared: func (other: This) -> Float {
+		distanceVector := this - other
+		distanceVector x * distanceVector x + distanceVector y * distanceVector y
+	}
 	swap: func -> This { This new(this y, this x) }
 	round: func -> This { This new(this x round(), this y round()) }
 	ceiling: func -> This { This new(this x ceil(), this y ceil()) }

--- a/test/math/FloatPoint2DTest.ooc
+++ b/test/math/FloatPoint2DTest.ooc
@@ -139,6 +139,10 @@ FloatPoint2DTest: class extends Fixture {
 			distance := point0 distance(point1)
 			expect(distance, is equal to(19.04f) within(0.01f))
 		})
+		this add("distanceSquared", func {
+			distance := point0 distanceSquared(point1)
+			expect(distance, is equal to(362.44f) within(0.01f))
+		})
 		this add("clamp", func {
 			clamped := this point1 clamp(this point0, this point2)
 			expect(clamped x, is equal to(this point0 x) within(this precision))


### PR DESCRIPTION
For use in e.g. optimized algorithms since it's cheaper than `distance`.