### PR TITLE
Allow CLI arguments without short identifier

### DIFF
--- a/source/cli/ArgumentParser.ooc
+++ b/source/cli/ArgumentParser.ooc
@@ -27,8 +27,11 @@ _Argument: class {
 	_textAction: Event1<Text>
 	_listAction: Event1<VectorList<Text>>
 	init: func (=_longIdentifier, =_shortIdentifier, =_parameters, =_action)
+	init: func ~noShort (=_longIdentifier, =_parameters, =_action)
 	init: func ~parameter (=_longIdentifier, =_shortIdentifier, =_parameters, =_textAction)
+	init: func ~parameterNoShort (=_longIdentifier, =_parameters, =_textAction)
 	init: func ~parameters (=_longIdentifier, =_shortIdentifier, =_parameters, =_listAction)
+	init: func ~parametersNoShort (=_longIdentifier, =_parameters, =_listAction)
 	init: func ~default (=_textAction)
 	free: override func {
 		this _longIdentifier free(Owner Receiver)
@@ -57,11 +60,20 @@ ArgumentParser: class {
 	add: func (longIdentifier: Text, shortIdentifier: Char, action: Event) {
 		this _arguments add(_Argument new(longIdentifier claim(), shortIdentifier, 0, action))
 	}
+	add: func ~noShort (longIdentifier: Text, action: Event) {
+		this _arguments add(_Argument new(longIdentifier claim(), 0, action))
+	}
 	add: func ~parameter (longIdentifier: Text, shortIdentifier: Char, action: Event1<Text>) {
 		this _arguments add(_Argument new(longIdentifier claim(), shortIdentifier, 1, action))
 	}
+	add: func ~parameterNoShort (longIdentifier: Text, action: Event1<Text>) {
+		this _arguments add(_Argument new(longIdentifier claim(), 1, action))
+	}
 	add: func ~parameters (longIdentifier: Text, shortIdentifier: Char, parameters: Int, action: Event1<VectorList<Text>>) {
 		this _arguments add(_Argument new(longIdentifier claim(), shortIdentifier, parameters, action))
+	}
+	add: func ~parametersNoShort (longIdentifier: Text, parameters: Int, action: Event1<VectorList<Text>>) {
+		this _arguments add(_Argument new(longIdentifier claim(), parameters, action))
 	}
 	addDefault: func (action: Event1<Text>) {
 		this _defaultArgument = _Argument new(action)

--- a/test/cli/ArgumentParserTest.ooc
+++ b/test/cli/ArgumentParserTest.ooc
@@ -92,6 +92,49 @@ ArgumentParserTest: class extends Fixture {
 			argumentCSecondValue free()
 			argumentCThirdValue free()
 		})
+		this add("No shortIdentifier", func {
+			inputList := VectorList<Text> new()
+			inputList add(t"-a")
+			inputList add(t"-12345")
+			inputList add(t"-argb")
+			inputList add(t"--argc")
+			inputList add(t"5")
+			inputList add(t"-10")
+			inputList add(t"15")
+			inputList add(t"--argd")
+			inputList add(t"1")
+			inputList add(t"2")
+			parser := ArgumentParser new()
+			argumentAValue: Text
+			argumentAValue = t""
+			argumentBValue: Text
+			argumentCFirstValue: Text
+			argumentCSecondValue: Text
+			argumentCThirdValue: Text
+			argumentDFirstValue: Text
+			argumentDSecondValue: Text
+			parser add(t"arga", Event1<Text> new(func (parameter: Text) { argumentAValue = parameter }))
+			parser add(t"argb", Event new(func { argumentBValue = t"b" }))
+			parser add(t"argc", 'c', 3, Event1<VectorList<Text>> new(func (list: VectorList<Text>) { argumentCFirstValue = list[0]; argumentCSecondValue = list[1]; argumentCThirdValue = list[2] }))
+			parser add(t"argd", 2, Event1<VectorList<Text>> new(func (list: VectorList<Text>) { argumentDFirstValue = list[0]; argumentDSecondValue = list[1] }))
+			parser parse(inputList)
+			expect(argumentAValue == t"")
+			expect(argumentBValue == t"b")
+			expect(argumentCFirstValue == t"5")
+			expect(argumentCSecondValue == t"-10")
+			expect(argumentCThirdValue == t"15")
+			expect(argumentDFirstValue == t"1")
+			expect(argumentDSecondValue == t"2")
+			inputList free()
+			parser free()
+			argumentAValue free()
+			argumentBValue free()
+			argumentCFirstValue free()
+			argumentCSecondValue free()
+			argumentCThirdValue free()
+			argumentDFirstValue free()
+			argumentDSecondValue free()
+		})
 	}
 }
 ArgumentParserTest new() run()


### PR DESCRIPTION
I have added `add` functions without the short identifier parameter in `CLIArgumentParser`.