### PR TITLE
Merged win32 and x11 modules into ui

### DIFF
--- a/ooc-ui.use
+++ b/ooc-ui.use
@@ -2,3 +2,9 @@ Name: ooc UI
 Description: User interface stuff
 SourcePath: source/ui
 Imports: NativeWindow
+Imports: x11/X11Window
+Imports: win32/Win32Window
+version(windows)
+	Libs: -lgdi32
+version(!windows)
+	Libs: -lX11

--- a/ooc-win32.use
+++ b/ooc-win32.use
@@ -1,6 +1,0 @@
-Name: ooc win32
-Description: win32 implementations for ooc
-SourcePath: source/ui/win32
-Imports: Win32Window
-version(windows)
-	Libs: -lgdi32

--- a/ooc-x11.use
+++ b/ooc-x11.use
@@ -1,6 +1,0 @@
-Name: ooc X11
-Description: X11 implementations for ooc
-SourcePath: source/ui/x11
-Imports: X11Window
-version(!windows)
-	Libs: -lX11

--- a/source/widgets/UnixWindow.ooc
+++ b/source/widgets/UnixWindow.ooc
@@ -20,7 +20,7 @@ use ooc-draw-gpu
 use ooc-math
 use ooc-draw
 use ooc-opengl
-use ooc-x11
+use ooc-ui
 
 version(unix || apple) {
 UnixWindowBase: class extends DisplayWindow {

--- a/source/widgets/Win32DisplayWindow.ooc
+++ b/source/widgets/Win32DisplayWindow.ooc
@@ -18,7 +18,7 @@
 import DisplayWindow
 use ooc-math
 use ooc-draw
-use ooc-win32
+use ooc-ui
 
 version(windows) {
 Win32DisplayWindow: class extends DisplayWindow {


### PR DESCRIPTION
Next step to remove widgets module. 
`X11` and `Win32` modules merged with `ui`
depends on https://github.com/cogneco/ooc-kean/pull/817