### PR TITLE
Added methods to test floating point equality within tolerance

### DIFF
--- a/source/math/FloatVector2D.ooc
+++ b/source/math/FloatVector2D.ooc
@@ -22,7 +22,7 @@ FloatVector2D: cover {
 	x, y: Float
 	area ::= this x * this y
 	length ::= this norm
-	empty ::= !(this x > 0 && this y > 0)
+	empty ::= this x equals(0.0f) || this y equals(0.0f) || this x < 0.0f || this y < 0.0f
 	norm ::= (this x squared() + this y squared()) sqrt()
 	azimuth ::= this y atan2(this x)
 	absolute ::= This new(Float absolute(this x), Float absolute(this y))

--- a/source/math/FloatVector3D.ooc
+++ b/source/math/FloatVector3D.ooc
@@ -24,7 +24,7 @@ FloatVector3D: cover {
 	x, y, z: Float
 	volume ::= this x * this y * this z
 	length ::= this norm
-	empty ::= this x == 0 || this y == 0 || this z == 0
+	empty ::= this x equals(0.0f) || this y equals(0.0f) || this z equals(0.0f)
 	norm ::= (this x squared() + this y squared() + this z squared()) sqrt()
 	azimuth ::= this y atan2(this x)
 	basisX: static This { get { This new(1, 0, 0) } }

--- a/source/sdk/math.ooc
+++ b/source/sdk/math.ooc
@@ -60,7 +60,7 @@ extend Short {
 }
 
 extend Int64 {
-	modulo: func (divisor: This) -> This { 
+	modulo: func (divisor: This) -> This {
 		result := this - (this / divisor) * divisor
 		result < 0 ? result + divisor : result
 	}
@@ -206,6 +206,7 @@ extend Double {
 		else
 			this
 	}
+	equals: func (other: This, tolerance := 0.0001) -> Bool { (this - other) abs() < tolerance }
 }
 
 extend Float {
@@ -360,6 +361,7 @@ extend Float {
 		result := coefficient toString() >> "E" & power toString()
 		result
 	}
+	equals: func (other: This, tolerance := 0.0001f) -> Bool { (this - other) abs() < tolerance }
 }
 
 extend LDouble {
@@ -395,4 +397,5 @@ extend LDouble {
 	ceil: extern (ceill) func -> This
 	floor: extern (floorl) func -> This
 	truncate: extern (truncl) func -> This
+	equals: func (other: This, tolerance := 0.0001) -> Bool { (this - other) abs() < tolerance }
 }

--- a/test/math/FloatSize2DTest.ooc
+++ b/test/math/FloatSize2DTest.ooc
@@ -148,6 +148,9 @@ FloatVector2DTest: class extends Fixture {
 			expect(empty empty, is true)
 			expect(empty area, is equal to(0.0f) within(this precision))
 			expect(this vector1 empty, is false)
+			almostZero := (0.1 + 0.1 + 0.1) - 0.3
+			empty = FloatVector2D new(almostZero, 0.1f)
+			expect(empty empty, is true)
 		})
 	}
 }

--- a/test/math/FloatSize3DTest.ooc
+++ b/test/math/FloatSize3DTest.ooc
@@ -137,6 +137,9 @@ FloatVector3DTest: class extends Fixture {
 			expect(empty empty, is true)
 			expect(empty volume, is equal to(0.0f) within(this precision))
 			expect(this vector0 empty, is false)
+			almostZero := (0.1 + 0.1 + 0.1) - 0.3
+			empty = FloatVector3D new(almostZero, almostZero, 0.1f)
+			expect(empty empty, is true)
 		})
 		this add("azimuth", func {
 			myvector := FloatVector3D new(1.0, 5.5, 0.1)


### PR DESCRIPTION
Updated `FloatVectorTest` with test that would previously fail due to floating point rounding errors.
Problem mentioned in https://github.com/cogneco/ooc-kean/issues/870 is not fixed here, it deserves its own PR.
@marcusnaslund can you review