### PR TITLE
LinkedList now automatically wraps data in a Cell

### DIFF
--- a/source/collections/LinkedList.ooc
+++ b/source/collections/LinkedList.ooc
@@ -39,7 +39,7 @@ LinkedList: class <T> {
 			raise("Index out of bounds in LinkedList add~withIndex")
 	}
 	get: func (index: SSizeT) -> T {
-		this getNode(index) data@
+		this getNode(index) data
 	}
 	getNode: func (index: SSizeT) -> Node<T> {
 		if (index < 0 || index >= this _size)
@@ -89,21 +89,20 @@ LinkedList: class <T> {
 	first: func -> T {
 		data: T
 		if (this _head next != this _head)
-			data = this _head next data@
+			data = this _head next data
 		data
 	}
 	last: func -> T {
 		data: T
 		if (this _head prev != this _head)
-			data = this _head prev data@
+			data = this _head prev data
 		data
 	}
 	removeAt: func (index: SSizeT) -> T {
-		item := null
+		item: T = null
 		if (this _head next != this _head && 0 <= index && index < this _size) {
 			toRemove := this getNode(index)
-			this removeNode(toRemove)
-			item = toRemove data
+			item = this removeNode(toRemove)
 		} else
 			raise("Index out of bounds in LinkedList removeAt")
 		item
@@ -117,13 +116,15 @@ LinkedList: class <T> {
 		}
 		result
 	}
-	removeNode: func (toRemove: Node<T>) {
+	removeNode: func (toRemove: Node<T>) -> T {
 		toRemove prev next = toRemove next
 		toRemove next prev = toRemove prev
 		toRemove prev = null
 		toRemove next = null
+		data := toRemove data
 		toRemove free()
 		this _size -= 1
+		data
 	}
 	removeLast: func -> Bool {
 		result := false
@@ -153,12 +154,20 @@ operator []= <T>(list: LinkedList<T>, index: Int, value: T) { list set(index, va
 Node: class <T> {
 	prev: This<T>
 	next: This<T>
-	data: T* //TODO: Auto-wrap covers in Cell<T>
+	_data: Cell<T>
+	data: T {
+		get { this _data get() }
+		set(value) { 
+			this _data free()
+			this _data = Cell new(value)
+		}
+	}
 	init: func
-	init: func ~withParams (=prev, =next, =data)
+	init: func ~withParams (=prev, =next, item: T) {
+		this _data = Cell new(item)
+	}
 	free: override func {
-		if (T inheritsFrom?(Object))
-			gc_free(data)
+		this _data free()
 		super()
 	}
 }

--- a/source/collections/LinkedList.ooc
+++ b/source/collections/LinkedList.ooc
@@ -154,20 +154,24 @@ operator []= <T>(list: LinkedList<T>, index: Int, value: T) { list set(index, va
 Node: class <T> {
 	prev: This<T>
 	next: This<T>
-	_data: Cell<T>
+	_data: Object
 	data: T {
-		get { this _data get() }
+		get { 
+			if (T inheritsFrom?(Object))
+				this _data
+			else
+				this _data as Cell<T> get()
+		}
 		set(value) { 
 			this _data free()
-			this _data = Cell new(value)
+			if (T inheritsFrom?(Object))
+				this _data = value
+			else
+				this _data = Cell<T> new(value)
 		}
 	}
 	init: func
 	init: func ~withParams (=prev, =next, item: T) {
 		this _data = Cell new(item)
-	}
-	free: override func {
-		this _data free()
-		super()
 	}
 }

--- a/source/collections/LinkedList.ooc
+++ b/source/collections/LinkedList.ooc
@@ -1,7 +1,7 @@
 import structs/List
 
 LinkedList: class <T> {
-	_size = 0 : SizeT
+	_size := 0
 	size ::= this _size as Int
 	_head: Node<T>
 	head ::= this _head
@@ -11,7 +11,7 @@ LinkedList: class <T> {
 		this _head next = this _head
 	}
 	free: override func {
-		this clear()
+		//this clear()
 		super()
 	}
 	add: func (data: T) {
@@ -20,7 +20,7 @@ LinkedList: class <T> {
 		this _head prev = node
 		this _size += 1
 	}
-	add: func ~withIndex (index: SSizeT, data: T) {
+	add: func ~withIndex (index: Int, data: T) {
 		if (index > 0 && index < this size) {
 			prevNode := this getNode(index - 1)
 			nextNode := prevNode next
@@ -38,10 +38,10 @@ LinkedList: class <T> {
 		} else
 			raise("Index out of bounds in LinkedList add~withIndex")
 	}
-	get: func (index: SSizeT) -> T {
+	get: func (index: Int) -> T {
 		this getNode(index) data
 	}
-	getNode: func (index: SSizeT) -> Node<T> {
+	getNode: func (index: Int) -> Node<T> {
 		if (index < 0 || index >= this _size)
 			raise("Index out of bounds in LinkedList getNode")
 		i := 0
@@ -58,7 +58,7 @@ LinkedList: class <T> {
 		this _head next = this _head
 		this _head prev = this _head
 	}
-	indexOf: func (data: T) -> SSizeT {
+	indexOf: func (data: T) -> Int {
 		current := this _head next
 		i := 0
 		index := -1
@@ -72,7 +72,7 @@ LinkedList: class <T> {
 		}
 		index
 	}
-	lastIndexOf: func (data: T) -> SSizeT {
+	lastIndexOf: func (data: T) -> Int {
 		current := this _head prev
 		i := this _size - 1
 		index := -1
@@ -98,7 +98,7 @@ LinkedList: class <T> {
 			data = this _head prev data
 		data
 	}
-	removeAt: func (index: SSizeT) -> T {
+	removeAt: func (index: Int) -> T {
 		item: T = null
 		if (this _head next != this _head && 0 <= index && index < this _size) {
 			toRemove := this getNode(index)
@@ -134,7 +134,7 @@ LinkedList: class <T> {
 		}
 		result
 	}
-	set: func (index: SSizeT, data: T) -> T {
+	set: func (index: Int, data: T) -> T {
 		node := this getNode(index)
 		previousData := node data
 		node data = data
@@ -154,7 +154,7 @@ operator []= <T>(list: LinkedList<T>, index: Int, value: T) { list set(index, va
 Node: class <T> {
 	prev: This<T>
 	next: This<T>
-	_data: Object
+	_data: Object = null
 	data: T {
 		get { 
 			if (T inheritsFrom?(Object))
@@ -163,15 +163,26 @@ Node: class <T> {
 				this _data as Cell<T> get()
 		}
 		set(value) { 
-			this _data free()
 			if (T inheritsFrom?(Object))
 				this _data = value
-			else
+			else {
+				if (this _data != null) {
+					(this _data as Cell) val = null
+					(this _data as Cell) free()
+				}
 				this _data = Cell<T> new(value)
+			}
 		}
 	}
 	init: func
 	init: func ~withParams (=prev, =next, item: T) {
 		this _data = Cell new(item)
+	}
+	free: override func {
+		if (this _data instanceOf?(Cell)) {
+			(this _data as Cell) val = null
+			(this _data as Cell) free()
+		}
+		super()
 	}
 }

--- a/source/collections/LinkedList.ooc
+++ b/source/collections/LinkedList.ooc
@@ -156,13 +156,13 @@ Node: class <T> {
 	next: This<T>
 	_data: Object = null
 	data: T {
-		get { 
+		get {
 			if (T inheritsFrom?(Object))
 				this _data
 			else
 				this _data as Cell<T> get()
 		}
-		set(value) { 
+		set(value) {
 			if (T inheritsFrom?(Object))
 				this _data = value
 			else {

--- a/test/collections/LinkedListTest.ooc
+++ b/test/collections/LinkedListTest.ooc
@@ -39,9 +39,10 @@ LinkedListTest: class extends Fixture {
 			linkedlist add(2)
 			linkedlist add(5)
 			linkedlist add(7)
-			linkedlist set(0, 42)
+			old := linkedlist set(0, 42)
 			item := linkedlist get(0)
 			expect(item, is equal to(42))
+			expect(old, is equal to(2))
 		})
 		this add("operators", func {
 			linkedlist := LinkedList<Int> new()


### PR DESCRIPTION
@davidhesselbom or @sebastianbaginski - can one of you take this?

I managed to fix the invalid memory read in `LinkedListTest`, it was due to the data being removed (old line 105), *before* reading it and returning. That also made it possible to use `Cell` instead of the pointer solution.

The user has to take care of the data being put in the `LinkedList`, but that should be nothing new.

Fixes #628 