### PR TITLE
Generalized linear interpolation method for raster images

### DIFF
--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -61,6 +61,16 @@ RasterBgr: class extends RasterPacked {
 		this apply(convert)
 		(convert as Closure) free()
 	}
+	resizeTo: override func (size: IntVector2D) -> This {
+		result: This
+		if (this size == size)
+			result = this copy()
+		else {
+			result = This new(size)
+			RasterCanvas resizeNearestNeighbour(this buffer pointer as ColorBgr*, result buffer pointer as ColorBgr*, this size, result size, this stride, result stride, this bytesPerPixel)
+		}
+		result
+	}
 	distance: func (other: Image) -> Float {
 		result := 0.0f
 		if (!other || (this size != other size))

--- a/source/draw/RasterCanvas.ooc
+++ b/source/draw/RasterCanvas.ooc
@@ -71,4 +71,17 @@ RasterCanvas: abstract class extends Canvas {
 	_map: func (point: IntPoint2D) -> IntPoint2D {
 		point + this _size / 2
 	}
+	resizeNearestNeighbour: static func <T> (sourceBuffer, resultBuffer: T*, sourceSize, resultSize: IntVector2D, sourceStride, resultStride, bytesPerPixel: Int) {
+		(resultWidth, resultHeight) := (resultSize x, resultSize y)
+		(sourceWidth, sourceHeight) := (sourceSize x, sourceSize y)
+		sourceStride /= bytesPerPixel
+		resultStride /= bytesPerPixel
+		for (row in 0 .. resultHeight) {
+			sourceRow := (sourceHeight * row) / resultHeight
+			for (column in 0 .. resultWidth) {
+				sourceColumn := (sourceWidth * column) / resultWidth
+				resultBuffer[column + resultStride * row] = sourceBuffer[sourceColumn + sourceStride * sourceRow]
+			}
+		}
+	}
 }

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -68,23 +68,10 @@ RasterMonochrome: class extends RasterPacked {
 			result = This new(size)
 			match (method) {
 				case InterpolationMode Smooth => This _resizeBilinear(this, result)
-				case => This _resizeNearestNeighbour(this, result)
+				case => RasterCanvas resizeNearestNeighbour(this buffer pointer as ColorMonochrome*, result buffer pointer as ColorMonochrome*, this size, result size, this stride, result stride, this bytesPerPixel)
 			}
 		}
 		result
-	}
-	_resizeNearestNeighbour: static func (source, result: This) {
-		resultBuffer := result buffer pointer
-		sourceBuffer := source buffer pointer
-		(resultWidth, resultHeight, resultStride) := (result size x, result size y, result stride)
-		(sourceWidth, sourceHeight, sourceStride) := (source size x, source size y, source stride)
-		for (row in 0 .. resultHeight) {
-			sourceRow := (sourceHeight * row) / resultHeight
-			for (column in 0 .. resultWidth) {
-				sourceColumn := (sourceWidth * column) / resultWidth
-				resultBuffer[column + resultStride * row] = sourceBuffer[sourceColumn + sourceStride * sourceRow]
-			}
-		}
 	}
 	_resizeBilinear: static func (source, result: This) {
 		resultBuffer := result buffer pointer

--- a/test/draw/RasterBgrTest.ooc
+++ b/test/draw/RasterBgrTest.ooc
@@ -63,6 +63,16 @@ RasterBgrTest: class extends Fixture {
 			image2 referenceCount decrease()
 			output free()
 		})
+		this add("resize", func {
+			outputFast := "test/draw/output/RasterBgr_resized.png"
+			image := RasterBgr open(this sourceSpace)
+			image2 := image resizeTo(image size * 2)
+			expect(image2 size == image size * 2)
+			image2 save(outputFast)
+			image referenceCount decrease()
+			image2 referenceCount decrease()
+			outputFast free()
+		})
 	}
 }
 


### PR DESCRIPTION
Method to rescale pixel buffers with linear interpolation is now parametrized with pixel type.
This is the first step to fix https://github.com/cogneco/ooc-kean/issues/732
To be honest I was afraid that we will have to rewrite it for every possible pixel type and size.

@marcusnaslund can you review

I must say I'm impressed that ooc supports member template methods. This is a standard feature in C++, yet not supported by some microsoft compilers :)