### PR TITLE
Implemented support for source and destination boxes in linear rescaling

### DIFF
--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -67,7 +67,7 @@ RasterBgr: class extends RasterPacked {
 			result = this copy()
 		else {
 			result = This new(size)
-			RasterCanvas resizeNearestNeighbour(this buffer pointer as ColorBgr*, result buffer pointer as ColorBgr*, this size, result size, this stride, result stride, this bytesPerPixel)
+			RasterCanvas resizeNearestNeighbour(this buffer pointer as ColorBgr*, result buffer pointer as ColorBgr*, IntBox2D new(this size), IntBox2D new(result size), this stride, result stride, this bytesPerPixel)
 		}
 		result
 	}

--- a/source/draw/RasterCanvas.ooc
+++ b/source/draw/RasterCanvas.ooc
@@ -71,16 +71,18 @@ RasterCanvas: abstract class extends Canvas {
 	_map: func (point: IntPoint2D) -> IntPoint2D {
 		point + this _size / 2
 	}
-	resizeNearestNeighbour: static func <T> (sourceBuffer, resultBuffer: T*, sourceSize, resultSize: IntVector2D, sourceStride, resultStride, bytesPerPixel: Int) {
-		(resultWidth, resultHeight) := (resultSize x, resultSize y)
-		(sourceWidth, sourceHeight) := (sourceSize x, sourceSize y)
+	resizeNearestNeighbour: static func <T> (sourceBuffer, resultBuffer: T*, sourceBox, resultBox: IntBox2D, sourceStride, resultStride, bytesPerPixel: Int) {
+		(resultWidth, resultHeight) := (resultBox size x, resultBox size y)
+		(sourceWidth, sourceHeight) := (sourceBox size x, sourceBox size y)
 		sourceStride /= bytesPerPixel
 		resultStride /= bytesPerPixel
-		for (row in 0 .. resultHeight) {
+		resultStartColumn := resultBox leftTop x
+		resultStartRow := resultBox leftTop y
+		for (row in sourceBox leftTop x .. resultHeight) {
 			sourceRow := (sourceHeight * row) / resultHeight
-			for (column in 0 .. resultWidth) {
+			for (column in sourceBox leftTop y .. resultWidth) {
 				sourceColumn := (sourceWidth * column) / resultWidth
-				resultBuffer[column + resultStride * row] = sourceBuffer[sourceColumn + sourceStride * sourceRow]
+				resultBuffer[(column + resultStartColumn) + resultStride * (row + resultStartRow)] = sourceBuffer[sourceColumn + sourceStride * sourceRow]
 			}
 		}
 	}

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -68,7 +68,7 @@ RasterMonochrome: class extends RasterPacked {
 			result = This new(size)
 			match (method) {
 				case InterpolationMode Smooth => This _resizeBilinear(this, result)
-				case => RasterCanvas resizeNearestNeighbour(this buffer pointer as ColorMonochrome*, result buffer pointer as ColorMonochrome*, this size, result size, this stride, result stride, this bytesPerPixel)
+				case => RasterCanvas resizeNearestNeighbour(this buffer pointer as ColorMonochrome*, result buffer pointer as ColorMonochrome*, IntBox2D new(this size), IntBox2D new(result size), this stride, result stride, this bytesPerPixel)
 			}
 		}
 		result

--- a/test/draw/RasterCanvasTest.ooc
+++ b/test/draw/RasterCanvasTest.ooc
@@ -3,6 +3,7 @@ use ooc-math
 use ooc-draw
 use ooc-draw-gpu
 use ooc-opengl
+import RasterCanvas
 
 RasterCanvasTest: class extends Fixture {
 	init: func {
@@ -103,6 +104,20 @@ RasterCanvasTest: class extends Fixture {
 			original free()
 			image free()
 			input free()
+			output free()
+		})
+		this add("resize with box", func {
+			inputFlower := "test/draw/input/Flower.png"
+			inputSpace := "test/draw/input/Space.png"
+			output := "test/draw/output/RasterCanvas_resizeWithBox.png"
+			imageFlower := RasterBgr open(inputFlower)
+			outputImage := RasterBgr open(inputSpace)
+			RasterCanvas resizeNearestNeighbour(imageFlower buffer pointer as ColorBgr*, outputImage buffer pointer as ColorBgr*, IntBox2D new(imageFlower size), IntBox2D new(20, 30, 100, 250), imageFlower stride, outputImage stride, imageFlower bytesPerPixel)
+			outputImage save(output)
+			imageFlower referenceCount decrease()
+			outputImage referenceCount decrease()
+			inputFlower free()
+			inputSpace free()
 			output free()
 		})
 	}


### PR DESCRIPTION
`source` and `destination` boxes added to the generic linear rescaling method.
This will be needed to implement `draw: override func ~ImageSourceDestination (image: Image, source, destination: IntBox2D)` function in Raster Canvas subclasses.
Test case included.
Updates to RasterCanvas subclasses will come later in separate PRs.
@marcusnaslund this is ready for review