### PR TITLE
Reduced memory leaks in Fixture

### DIFF
--- a/test/unit/StringTest.ooc
+++ b/test/unit/StringTest.ooc
@@ -36,7 +36,8 @@ StringTest: class extends Fixture {
 		this add("code is not equal to empty", func { expect("code", isNotEqualToEmpty) })
 		isNotEqualToCode := is not equal to("code") // FIXME: Does not work to skip variable and put expression below, why?
 		this add("null is not equal to code", func { expect(null, isNotEqualToCode) })
-		this add("empty is not equal to code", func { expect("", isNotEqualToCode) })
+		isNotEqualToCode2 := is not equal to("code") // FIXME: Does not work to skip variable and put expression below, why?
+		this add("empty is not equal to code", func { expect("", isNotEqualToCode2) })
 	}
 }
 StringTest new() run()


### PR DESCRIPTION
An example of valgrind output for `test/math` before:
```
==00:00:00:20.094 29312==    definitely lost: 16,078,012 bytes in 2,339 blocks
==00:00:00:20.094 29312==    indirectly lost: 19,915,488 bytes in 611,227 blocks
==00:00:00:20.094 29312==      possibly lost: 108 bytes in 3 blocks
```

and after:
```
==00:00:00:20.443 28643==    definitely lost: 20,888,344 bytes in 203,616 blocks
==00:00:00:20.443 28643==    indirectly lost: 1,402,236 bytes in 207,626 blocks
==00:00:00:20.443 28643==      possibly lost: 0 bytes in 0 blocks
```

And this should be even better once we add `. free()` to all tests. I will get to work on that after this.

@sebastianbaginski - can you peer review?