### PR TITLE
Removed async parameter from toRaster.

### DIFF
--- a/source/draw/gpu/GpuContext.ooc
+++ b/source/draw/gpu/GpuContext.ooc
@@ -39,7 +39,7 @@ GpuContext: abstract class extends AbstractContext {
 	packToRgba: abstract func (source: GpuImage, target: GpuImage, viewport: IntBox2D)
 	finish: func { this createFence() sync() . wait() . free() }
 
-	toRaster: virtual func (gpuImage: GpuImage, async: Bool = false) -> RasterImage { gpuImage toRasterDefault() }
+	toRaster: virtual func (gpuImage: GpuImage) -> RasterImage { gpuImage toRasterDefault() }
 	toRasterAsync: virtual func (gpuImage: GpuImage) -> (RasterImage, GpuFence) { Debug raise("toRasterAsync unimplemented") }
 }
 }

--- a/source/draw/gpu/GpuImage.ooc
+++ b/source/draw/gpu/GpuImage.ooc
@@ -53,7 +53,7 @@ GpuImage: abstract class extends Image {
 	distance: func (other: This) -> Float { raise("Using unimplemented function distance in GpuImage class"); 0.0f }
 
 	upload: abstract func (image: RasterImage)
-	toRaster: func (async: Bool = false) -> RasterImage { this _context toRaster(this, async) }
+	toRaster: func -> RasterImage { this _context toRaster(this) }
 	toRasterAsync: func -> (RasterImage, GpuFence) { this _context toRasterAsync(this) }
 	toRasterDefault: abstract func -> RasterImage
 }

--- a/source/draw/gpu/opengl/AndroidContext.ooc
+++ b/source/draw/gpu/opengl/AndroidContext.ooc
@@ -84,26 +84,22 @@ AndroidContext: class extends OpenGLContext {
 		}
 		(ByteBuffer new(sourcePointer, length, recover), fence)
 	}
-	toRaster: func ~monochrome (gpuImage: OpenGLMonochrome, async: Bool) -> RasterImage {
+	toRaster: func ~monochrome (gpuImage: OpenGLMonochrome) -> RasterImage {
 		(buffer, fence) := this toBuffer(gpuImage, this _packMonochrome)
-		if (!async)
-			fence wait()
 		fence free()
 		RasterMonochrome new(buffer, gpuImage size)
 	}
-	toRaster: func ~uv (gpuImage: OpenGLUv, async: Bool) -> RasterImage {
+	toRaster: func ~uv (gpuImage: OpenGLUv) -> RasterImage {
 		(buffer, fence) := this toBuffer(gpuImage, this _packUv)
-		if (!async)
-			fence wait()
 		fence free()
 		RasterUv new(buffer, gpuImage size)
 	}
-	toRaster: override func (gpuImage: GpuImage, async: Bool = false) -> RasterImage {
+	toRaster: override func (gpuImage: GpuImage) -> RasterImage {
 		match (gpuImage) {
 			case (image : OpenGLMonochrome) =>
-				this isAligned(image channels * image size x) ? this toRaster(image, async) : super(image)
+				this isAligned(image channels * image size x) ? this toRaster(image) : super(image)
 			case (image : OpenGLUv) =>
-				this isAligned(image channels * image size x) ? this toRaster(image, async) : super(image)
+				this isAligned(image channels * image size x) ? this toRaster(image) : super(image)
 			case => super(gpuImage)
 		}
 	}

--- a/source/draw/gpu/opengl/OpenGLContext.ooc
+++ b/source/draw/gpu/opengl/OpenGLContext.ooc
@@ -171,7 +171,7 @@ OpenGLContext: class extends GpuContext {
 	}
 	createFence: func -> GpuFence { OpenGLFence new(this) }
 	toRasterAsync: override func (gpuImage: GpuImage) -> (RasterImage, GpuFence) {
-		result := this toRaster(gpuImage, true)
+		result := this toRaster(gpuImage)
 		fence := this createFence()
 		fence sync()
 		(result, fence)


### PR DESCRIPTION
@davidpiuva is this ok with you? From now on `toRaster` is strictly synchronous so you have to use `toRasterAsync` for asynchronus reads.

* Breaks API