### PR TITLE
Fixed 16 MB memory leak in Random generator tests

### DIFF
--- a/test/math/FloatRandomGeneratorTest.ooc
+++ b/test/math/FloatRandomGeneratorTest.ooc
@@ -82,6 +82,7 @@ FloatRandomGeneratorTest: class extends Fixture {
 				mean += values[i]
 			mean /= values length
 			expect(Float absolute(mean - expectedMean) < tolerance)
+			values free()
 		})
 		this add("gaussian distribution", func {
 			expectedMean := -3.0f
@@ -100,6 +101,7 @@ FloatRandomGeneratorTest: class extends Fixture {
 			deviation = sqrt(deviation / values length)
 			expect(Float absolute(mean - expectedMean) < tolerance)
 			expect(Float absolute(deviation - expectedDeviation) < tolerance)
+			values free()
 		})
 		this add("uniform range", func {
 			uniformGenerator := FloatUniformRandomGenerator new()

--- a/test/math/IntRandomGeneratorTest.ooc
+++ b/test/math/IntRandomGeneratorTest.ooc
@@ -34,6 +34,7 @@ IntRandomGeneratorTest: class extends Fixture {
 				mean += values[i]
 			mean /= values length
 			expect(Int absolute(mean - expectedMean) < tolerance)
+			values free()
 		})
 		this add("gaussian distribution", func {
 			expectedMean := 2
@@ -51,6 +52,7 @@ IntRandomGeneratorTest: class extends Fixture {
 			deviation = sqrt(deviation / values length)
 			expect(Int absolute(mean - expectedMean) < 2)
 			expect(Int absolute(deviation - expectedDeviation) < 2)
+			values free()
 		})
 		this add("uniform range", func {
 			uniformGenerator := IntUniformRandomGenerator new()


### PR DESCRIPTION
All the other big ones are related to `Raster` classes, so I'm hoping on you @sebastianbaginski 