### PR TITLE
Debug can now print Text

### DIFF
--- a/source/base/Debug.ooc
+++ b/source/base/Debug.ooc
@@ -15,6 +15,7 @@
 * along with this software. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use ooc-base
 import io/FileWriter
 
 DebugLevel: enum {
@@ -28,15 +29,20 @@ DebugLevel: enum {
 }
 
 Debug: class {
-	_level: static Int = DebugLevel Everything
+	_level: static DebugLevel = DebugLevel Everything
 	printFunction: static Func (String) = func (s: String) { println(s) }
 	initialize: static func (f: Func (String)) {
 		This printFunction = f
 	}
-	print: static func (printOut: String, level: Int = 1) {
+	print: static func (string: String, level := DebugLevel Everything) {
 		if (This _level == level || (This _level == DebugLevel Everything) ) {
-			This printFunction(printOut)
+			This printFunction(string)
 		}
+	}
+	print: static func ~text (text: Text, level := DebugLevel Everything) {
+		string := text toString()
+		This print(string, level)
+		string free()
 	}
 	kean_base_debug_registerCallback: unmangled static func (print: Pointer) {
 		f := (print, null) as Func (Char*)
@@ -45,5 +51,10 @@ Debug: class {
 	raise: static func (message: String) {
 		This print(message)
 		raise(message)
+	}
+	raise: static func ~text (message: Text) {
+		string := message toString()
+		This raise(string)
+		string free()
 	}
 }

--- a/test/base/DebugPrintTest.ooc
+++ b/test/base/DebugPrintTest.ooc
@@ -19,8 +19,8 @@ use ooc-base
 
 version(debugTests) {
 	Debug initialize(func (message: String) { println(message) } )
-	Debug _level = 3
-	Debug print("TEST1", 2)
+	Debug _level = DebugLevel Warning
+	Debug print("TEST1", DebugLevel Notification)
 
-	Debug print("TEST2", 3)
+	Debug print("TEST2", DebugLevel Warning)
 }


### PR DESCRIPTION
`Text` class can now be used with `Debug` module.
@emilwestergren take a look

The default value for enum changed recently, is `1` still a valid default value for `print` in `Debug` ?