### PR TITLE
DateTime now has toText instead of toString

### DIFF
--- a/source/base/DateTime.ooc
+++ b/source/base/DateTime.ooc
@@ -109,24 +109,23 @@ DateTime: cover {
 	//	%ss - second
 	//	%zzzz - millisecond
 	// <param name="format">output format specification</param>
-	toString: func (format := This defaultFormat) -> String {
-		result := format
+	toText: func (format := This defaultFormat) -> Text {
+		result := format copy()
 		data := This _ticksToDateTimeHelper(this ticks)
-		result = result replaceAll("%yyyy", "%d" format(data year))
-		result = result replaceAll("%yy", "%02d" format(data year % 100))
-		result = result replaceAll("%MM", "%02d" format(data month))
-		result = result replaceAll("%dd", "%02d" format(data day))
-		result = result replaceAll("%M", "%d" format(data month))
-		result = result replaceAll("%d", "%d" format(data day))
-		result = result replaceAll("%hh", "%02d" format(data hour))
-		result = result replaceAll("%mm", "%02d" format(data minute))
-		result = result replaceAll("%ss", "%02d" format(data second))
-		result = result replaceAll("%h", "%d" format(data hour))
-		result = result replaceAll("%m", "%d" format(data minute))
-		result = result replaceAll("%s", "%d" format(data second))
-		result = result replaceAll("%zzz", "%03d" format(data millisecond))
-		result = result replaceAll("%z", "%d" format(data millisecond))
-		result
+		result = result replaceAll(t"%yyyy", t"%d" format(data year))
+		result = result replaceAll(t"%yy", t"%02d" format(data year % 100))
+		result = result replaceAll(t"%MM", t"%02d" format(data month))
+		result = result replaceAll(t"%dd", t"%02d" format(data day))
+		result = result replaceAll(t"%M", t"%d" format(data month))
+		result = result replaceAll(t"%d", t"%d" format(data day))
+		result = result replaceAll(t"%hh", t"%02d" format(data hour))
+		result = result replaceAll(t"%mm", t"%02d" format(data minute))
+		result = result replaceAll(t"%ss", t"%02d" format(data second))
+		result = result replaceAll(t"%h", t"%d" format(data hour))
+		result = result replaceAll(t"%m", t"%d" format(data minute))
+		result = result replaceAll(t"%s", t"%d" format(data second))
+		result = result replaceAll(t"%zzz", t"%03d" format(data millisecond))
+		result replaceAll(t"%z", t"%d" format(data millisecond))
 	}
 
 	compareTo: func (other: This) -> Order {
@@ -178,7 +177,7 @@ DateTime: cover {
 	ticksPerWeek: static const UInt64 = This ticksPerDay * 7
 	ticksPerFourYears: static const Int64 = This daysPerFourYears * This ticksPerDay
 	/* default date/time printing format */
-	defaultFormat: static const String = "%yyyy-%MM-%dd %hh:%mm:%ss::%zzzz"
+	defaultFormat: static const Text = t"%yyyy-%MM-%dd %hh:%mm:%ss::%zzzz"
 
 	now: static This {
 		get {

--- a/source/base/TextBuilder.ooc
+++ b/source/base/TextBuilder.ooc
@@ -89,6 +89,7 @@ TextBuilder: class {
 		}
 		else
 			result = TextBuffer empty
+		separator free(Owner Receiver)
 		Text new(result give())
 	}
 	println: func { this toText() println() }

--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -54,7 +54,9 @@ Fixture: abstract class {
 	run: func -> Bool {
 		failures := VectorList<TestFailedException> new(32, false)
 		result := true
-		This _print(DateTime now toString("%hh:%mm:%ss") + " " + this name + " ")
+		dateString := DateTime now toText(t"%hh:%mm:%ss") toString() & " " << this name + " "
+		This _print(dateString)
+		dateString free()
 		timer := ClockTimer new() . start()
 		for (i in 0 .. this tests count) {
 			test := tests[i]
@@ -78,7 +80,9 @@ Fixture: abstract class {
 		This _print(result ? " done" : " failed")
 		testTime := timer stop() / 1000.0
 		This totalTime += testTime
-		This _print(" in %.2fs, total: %.2fs\n" format(testTime, This totalTime))
+		timeString := t" in %.2fs, total: %.2fs\n" format(testTime, This totalTime) toString()
+		This _print(timeString)
+		timeString free()
 		if (!result) {
 			for (i in 0 .. failures count) {
 				f := failures[i]

--- a/test/base/DateTimeTest.ooc
+++ b/test/base/DateTimeTest.ooc
@@ -166,17 +166,17 @@ DateTimeTest: class extends Fixture {
 			d1 -= TimeSpan week()
 			expect((d2 - d1) elapsedDays() == 6)
 		})
-		this add("toString", func {
+		this add("toText", func {
 			date := DateTime new(1643, 12, 31, 23, 58, 59, 999)
-			expect(date toString("%yyyy-%MM-%dd %hh:%mm:%ss.%zzz"), is equal to("1643-12-31 23:58:59.999"))
-			expect(date toString("%yy-%M-%d %h:%m:%s.%z"), is equal to("43-12-31 23:58:59.999"))
+			expect(date toText(t"%yyyy-%MM-%dd %hh:%mm:%ss.%zzz"), is equal to(t"1643-12-31 23:58:59.999"))
+			expect(date toText(t"%yy-%M-%d %h:%m:%s.%z"), is equal to(t"43-12-31 23:58:59.999"))
 			date = DateTime new(1998, 7, 18, 1, 44, 31, 742)
-			expect(date toString("date is : %yy, %M, %dd; hour: %hh-%mm-%ss"), is equal to("date is : 98, 7, 18; hour: 01-44-31"))
-			expect(date toString("%yyyy/%dd/%MM"), is equal to("1998/18/07"))
-			expect(date toString() == date toString(DateTime defaultFormat))
+			expect(date toText(t"date is : %yy, %M, %dd; hour: %hh-%mm-%ss"), is equal to(t"date is : 98, 7, 18; hour: 01-44-31"))
+			expect(date toText(t"%yyyy/%dd/%MM"), is equal to(t"1998/18/07"))
+			expect(date toText() == date toText(DateTime defaultFormat))
 			date = DateTime new ~fromYearMonthDay(1, 1, 1)
-			expect(date toString("start date is: %yy %M %d, %hh-%mm-%ss-%zzz"), is equal to("start date is: 01 1 1, 00-00-00-000"))
-			expect(date toString("%h-%m-%s-%z"), is equal to("0-0-0-0"))
+			expect(date toText(t"start date is: %yy %M %d, %hh-%mm-%ss-%zzz"), is equal to(t"start date is: 01 1 1, 00-00-00-000"))
+			expect(date toText(t"%h-%m-%s-%z"), is equal to(t"0-0-0-0"))
 		})
 		this add("current time", func {
 			d := DateTime now

--- a/test/base/TextBuilderTest.ooc
+++ b/test/base/TextBuilderTest.ooc
@@ -28,6 +28,7 @@ TextBuilderTest: class extends Fixture {
 			tb append('b')
 			tb append('c')
 			expect(tb == t"test test dataabc")
+			tb free()
 		})
 		this add("prepend", func {
 			tb := TextBuilder new(t"World")
@@ -65,6 +66,7 @@ TextBuilderTest: class extends Fixture {
 			t := sb toText()
 			s := t take() toString()
 			expect(s == t)
+			s free()
 		})
 		this add("join", func {
 			tb := TextBuilder new()


### PR DESCRIPTION
Depends on https://github.com/cogneco/ooc-kean/pull/928

`memcheck` log from master (`./test.sh base/DateTime`):
>==00:00:00:01.042 20316== HEAP SUMMARY:
>==00:00:00:01.042 20316==     in use at exit: 149,404 bytes in 2,040 blocks
>==00:00:00:01.042 20316==   total heap usage: 2,396 allocs, 356 frees, 160,406 bytes allocated
>==00:00:00:01.042 20316== 
>==00:00:00:01.065 20316== LEAK SUMMARY:
>==00:00:00:01.065 20316==    definitely lost: 17,024 bytes in 495 blocks
>==00:00:00:01.065 20316==    indirectly lost: 106,180 bytes in 708 blocks

report for this branch:
>==00:00:00:01.088 20622== HEAP SUMMARY:
>==00:00:00:01.088 20622==     in use at exit: 26,680 bytes in 775 blocks
>==00:00:00:01.088 20622==   total heap usage: 2,289 allocs, 1,514 frees, 299,762 bytes allocated
>==00:00:00:01.088 20622== 
>==00:00:00:01.097 20622== LEAK SUMMARY:
>==00:00:00:01.097 20622==    definitely lost: 264 bytes in 11 blocks
>==00:00:00:01.097 20622==    indirectly lost: 3,160 bytes in 19 blocks

Remaining are mostly `Format` related.