### PR TITLE
Cleaned up Env.ooc and System.ooc

### DIFF
--- a/source/sdk/os/Env.ooc
+++ b/source/sdk/os/Env.ooc
@@ -3,58 +3,46 @@ include stdlib | (__USE_BSD)
 getenv: extern func (path: CString) -> CString
 
 version (!windows) {
-    setenv: extern func (key, value: CString, overwrite: Bool) -> Int
-    unsetenv: extern func (key: CString) -> Int
-}
-version (windows) {
-    putenv: extern func (str: CString) -> Int
+	setenv: extern func (key, value: CString, overwrite: Bool) -> Int
+	unsetenv: extern func (key: CString) -> Int
+} else {
+	putenv: extern func (str: CString) -> Int
 }
 
 Env: class {
-    /** returns an environment variable. if not found, it returns null */
-    get: static func (variableName: String) -> String {
-        x := getenv(variableName as CString)
-        x != null ? x toString() : null
-    }
-
-    set: static func (key, value: String, overwrite: Bool) -> Int {
-        if(key != null && value != null) {
-            version(windows) {
-                // todo: handle overwrite
-                return putenv( "%s=%s" format(key toCString(), value toCString()) toCString() )
-            }
-            version(!windows) {
-                return setenv(key toCString(), value toCString(), overwrite)
-            }
-        }
-        return -1
-    }
-
-    set: static func ~overwrite (key, value: String) -> Int {
-        set(key, value, true)
-    }
-
-    unset: static func (key: String) -> Int {
-        version(windows) {
-            // under mingw, this unsets the key
-            return putenv((key + "=") toCString())
-        }
-        version(!windows) {
-            unsetenv(key toCString())
-            return 0
-        }
-        return -1
-    }
-
-    /* clearenv is not used since it's not part of the POSIX-2001 standard
-     * and not available, for example, on OSX */
+	// returns an environment variable. if not found, it returns null
+	get: static func (variableName: String) -> String {
+		x := getenv(variableName as CString)
+		x != null ? x toString() : null
+	}
+	set: static func (key, value: String, overwrite: Bool) -> Int {
+		result := -1
+		if (key != null && value != null) {
+			version(windows)
+				result = putenv( "%s=%s" format(key toCString(), value toCString()) toCString() )
+			else
+				result = setenv(key toCString(), value toCString(), overwrite)
+		}
+		result
+	}
+	set: static func ~overwrite (key, value: String) -> Int {
+		set(key, value, true)
+	}
+	unset: static func (key: String) -> Int {
+		result := -1
+		version(windows) {
+			// under mingw, this unsets the key
+			result = putenv((key + "=") toCString())
+		} else {
+			unsetenv(key toCString())
+			result = 0
+		}
+		result
+	}
 }
-
 operator [] (c: EnvClass, key: String) -> String {
-    Env get(key)
+	Env get(key)
 }
-
 operator []= (c: EnvClass, key, value: String) {
-    Env set(key, value, true)
+	Env set(key, value, true)
 }
-

--- a/source/sdk/os/System.ooc
+++ b/source/sdk/os/System.ooc
@@ -1,84 +1,72 @@
-
 import os/unistd
 
-// Windows
 version(windows) {
-    // for GetSystemInfo, GetComputerNameEx.
-    // 0x500 is the minimum required version, otherwise it won't link
-    include windows | (_WIN32_WINNT=0x0500)
-    
-    SystemInfo: cover from SYSTEM_INFO {
-        numberOfProcessors: extern(dwNumberOfProcessors) UInt32
-    }
-    GetSystemInfo: extern func (SystemInfo*)
+	// for GetSystemInfo, GetComputerNameEx.
+	// 0x500 is the minimum required version, otherwise it won't link
+	include windows | (_WIN32_WINNT=0x0500)
 
-    /* This should use values from headers, but they seem to be missing it in MinGW. Woops? */
-    COMPUTER_NAME_FORMAT: enum {
-        NET_BIOS = 0
-        DNS_HOSTNAME
-        DNS_DOMAIN
-        DNS_FULLY_QUALIFIED
-        PHYSICAL_NET_BIOS
-        PHYSICAL_DNS_HOSTNAME
-        PHYSICAL_DNS_DOMAIN
-        PHYSICAL_DNS_FULLY_QUALIFIED
-        MAX
-    }
+	SystemInfo: cover from SYSTEM_INFO {
+		numberOfProcessors: extern (dwNumberOfProcessors) UInt32
+	}
+	GetSystemInfo: extern func (SystemInfo*)
 
-    GetComputerNameEx: extern func (COMPUTER_NAME_FORMAT, CString, UInt32*)
+	// This should use values from headers, but they seem to be missing it in MinGW
+	COMPUTER_NAME_FORMAT: enum {
+		NET_BIOS = 0
+		DNS_HOSTNAME
+		DNS_DOMAIN
+		DNS_FULLY_QUALIFIED
+		PHYSICAL_NET_BIOS
+		PHYSICAL_DNS_HOSTNAME
+		PHYSICAL_DNS_DOMAIN
+		PHYSICAL_DNS_FULLY_QUALIFIED
+		MAX
+	}
+
+	GetComputerNameEx: extern func (COMPUTER_NAME_FORMAT, CString, UInt32*)
 }
 
 // Linux, OSX 10.4+
 version(linux || apple) {
-    include unistd // for sysconf
-
-    sysconf: extern func (Int) -> Long
-    _SC_NPROCESSORS_ONLN: extern Int
+	include unistd // for sysconf
+	sysconf: extern func (Int) -> Long
+	_SC_NPROCESSORS_ONLN: extern Int
 }
 
 System: class {
-
-    numProcessors: static func -> Int {
-        // Source:
-        // http://stackoverflow.com/questions/150355/programmatically-find-the-number-of-cores-on-a-machine
-        
-        version(windows) {
-            sysinfo: SystemInfo
-            GetSystemInfo(sysinfo&)
-            return sysinfo numberOfProcessors
-        }
-
-        version(linux || apple) {
-            // Linux, OSX 10.4+
-            return sysconf(_SC_NPROCESSORS_ONLN)
-        }
-        
-        1 // fallback
-    }
-
-    hostname: static func -> String {
-        version (windows) {
-            bufSize: UInt32 = 0
-            GetComputerNameEx(COMPUTER_NAME_FORMAT DNS_HOSTNAME, null, bufSize&)
-            hostname := Buffer new(bufSize)
-            GetComputerNameEx(COMPUTER_NAME_FORMAT DNS_HOSTNAME, hostname data as Pointer, bufSize&)
-            hostname sizeFromData()
-            return hostname toString()
-        }
-
-        version (linux || apple) {
-            BUF_SIZE = 255 : SizeT
-            hostname := Buffer new(BUF_SIZE + 1) // we alloc one byte more so we're always zero terminated
-            // according to docs, if the hostname is longer than the buffer,
-            // the result will be truncated and zero termination is not guaranteed
-            result := gethostname(hostname data as Pointer, BUF_SIZE)
-            if(result != 0) Exception new("System host name longer than 256 characters!!") throw()
-            hostname sizeFromData()
-            return hostname toString()
-        }
-
-        "<unknown>" // fallback
-    }
-
+	numProcessors: static func -> Int {
+		result := 1
+		version(windows) {
+			sysinfo: SystemInfo
+			GetSystemInfo(sysinfo&)
+			result = sysinfo numberOfProcessors
+		}
+		version(linux || apple) {
+			// Linux, OSX 10.4+
+			result = sysconf(_SC_NPROCESSORS_ONLN)
+		}
+		result
+	}
+	hostname: static func -> String {
+		result: String
+		version (windows) {
+			bufSize: UInt32 = 0
+			GetComputerNameEx(COMPUTER_NAME_FORMAT DNS_HOSTNAME, null, bufSize&)
+			hostname := Buffer new(bufSize)
+			GetComputerNameEx(COMPUTER_NAME_FORMAT DNS_HOSTNAME, hostname data as Pointer, bufSize&)
+			hostname sizeFromData()
+			result = hostname toString()
+		}
+		version (linux || apple) {
+			BUF_SIZE = 255 : SizeT
+			hostname := Buffer new(BUF_SIZE + 1) // we alloc one byte more so we're always zero terminated
+			// according to docs, if the hostname is longer than the buffer,
+			// the result will be truncated and zero termination is not guaranteed
+			result := gethostname(hostname data as Pointer, BUF_SIZE)
+			if (result != 0) Exception new("System host name longer than 256 characters!!") throw()
+			hostname sizeFromData()
+			result = hostname toString()
+		}
+		result
+	}
 }
-


### PR DESCRIPTION
Used in several parts of the SDK. Cleaned up.

@davidhesselbom or @sebastianbaginski - peer review?
(Hint: append ?w=1 to the URL when looking at the diff)