### PR TITLE
Removed the extra math.use

### DIFF
--- a/source/sdk/math.use
+++ b/source/sdk/math.use
@@ -1,3 +1,0 @@
-Name: math
-Description: math lib
-Libs: -lm


### PR DESCRIPTION
We have one in the root directory with the exact same contents.
This one is in the wrong place and is hence not used.