### PR TITLE
Removed ArrayList dependancy from Iterable<T>

### DIFF
--- a/source/sdk/lang/Iterators.ooc
+++ b/source/sdk/lang/Iterators.ooc
@@ -1,36 +1,24 @@
-import structs/[List, ArrayList] /* for Iterable<T> toArrayList */
-
-/**
- * iterators
- */
 Iterable: abstract class <T> {
 	iterator: abstract func -> Iterator<T>
-	/** Return the contents of the iterable as an ArrayList. */
-	toList: func -> ArrayList<T> {
-		result := ArrayList<T> new()
-		for(elem: T in this)
-			result add(elem)
-		result
-	}
 	reduce: func (f: Func (T, T) -> T) -> T {
 		iter := iterator()
 		acc := f(iter next(), iter next())
-		while(iter hasNext?())
+		while (iter hasNext?())
 			acc = f(acc, iter next())
 		acc
 	}
 	each: func (f: Func (T)) {
-		for(elem in this)
+		for (elem in this)
 			f(elem)
 	}
 	// Return false to break
 	eachUntil: func (f: Func (T) -> Bool) {
-		for(elem in this)
-			if(!f(elem)) break
+		for (elem in this)
+			if (!f(elem)) break
 	}
 	each: func ~withIndex (f: Func (T, Int)) {
 		index := 0
-		for(elem in this) {
+		for (elem in this) {
 			f(elem, index)
 			index += 1
 		}
@@ -46,15 +34,15 @@ BackIterable: abstract class <T> extends Iterable<T> {
 			iter next()
 		return iter
 	}
-	forward: func -> BackIterator<T> {iterator()}
-	backward: func -> BackIterator<T> {backIterator() reversed()}
+	forward: func -> BackIterator<T> { iterator() }
+	backward: func -> BackIterator<T> { backIterator() reversed() }
 }
 
 Iterator: abstract class <T> extends Iterable<T> {
 	hasNext?: abstract func -> Bool
 	next: abstract func -> T
 	remove: abstract func -> Bool
-	iterator: func -> Iterator<T> {this}
+	iterator: func -> This<T> { this }
 	map: func<T, S> (S: Class, function: Func(T) -> S) -> This<S> {
 		_MappingIterator<T, S> new(this, function)
 	}
@@ -63,7 +51,7 @@ Iterator: abstract class <T> extends Iterable<T> {
 BackIterator: abstract class <T> extends Iterator<T> {
 	hasPrev?: abstract func -> Bool
 	prev: abstract func -> T
-	iterator: func -> BackIterator<T> { this }
+	iterator: func -> This<T> { this }
 	reversed: func -> ReverseIterator<T> {
 		iter := ReverseIterator<T> new()
 		iter iterator = this
@@ -80,13 +68,13 @@ ReverseIterator: class <T> extends BackIterator<T> {
 	prev: func -> T { iterator next() }
 	remove: func -> Bool { iterator remove() }
 	reversed: func -> BackIterator<T> { iterator }
-	iterator: func -> ReverseIterator<T> { this }
+	iterator: func -> This<T> { this }
 }
 
 _MappingIterator: class <T, S> extends Iterator<S> {
 	_backend: Iterator<T>
 	_mapFunction: Func(T) -> S
-	init: func(=_backend, =_mapFunction)
+	init: func (=_backend, =_mapFunction)
 	free: func {
 		this _backend free()
 		super()


### PR DESCRIPTION
Removed the not used `toList` from `Iterable<T>`. I assume we will continue to use iterators, but we certainly don't want `ArrayList`. 

Also made some quick fixes to make the file magic compliant.

Since you touched this file last time, I'm asking you for peer review @thomasfanell 