### PR TITLE
fixed some memory leaks for Constraint classes

### DIFF
--- a/source/unit/Constraints.ooc
+++ b/source/unit/Constraints.ooc
@@ -31,6 +31,19 @@ Modifier: abstract class {
 	child: This = null
 	init: func
 	init: func ~parent (=parent)
+	free: override func {
+		if (this child) {
+			if (this child parent == this)
+				this child parent = null
+			this child free()
+		}
+		if (this parent) {
+			if (this parent child == this)
+				this parent child = null
+			this parent free()
+		}
+		super()
+	}
 	verify: func ~parent (value: Object, =child) -> Bool {
 		this parent != null ? this parent verify(value, this): this test(value)
 	}
@@ -274,18 +287,18 @@ CompareWithinConstraint: class extends CompareConstraint {
 		this precision = precision as LDouble
 		this comparer = func (value, correct: Object) -> Bool { this testChild(value) }
 		f := func (value, correct: Object) -> Bool { (value as Cell<Float> get() - correct as Cell<Float> get()) abs() < precision }
-		CompareConstraint new(this, this correct, f, ComparisonType Within)
+		CompareConstraint new(this, Cell<Float> new(this correct as Cell<Float> get()), f, ComparisonType Within)
 	}
 	within: func ~double (precision: Double) -> CompareConstraint {
 		this precision = precision as Double
 		this comparer = func (value, correct: Object) -> Bool { this testChild(value) }
 		f := func (value, correct: Object) -> Bool { (value as Cell<Double> get() - correct as Cell<Double> get()) abs() < precision }
-		CompareConstraint new(this, this correct, f, ComparisonType Within)
+		CompareConstraint new(this, Cell<Double> new(this correct as Cell<Double> get()), f, ComparisonType Within)
 	}
 	within: func ~ldouble (=precision) -> CompareConstraint {
 		this comparer = func (value, correct: Object) -> Bool { this testChild(value) }
 		f := func (value, correct: Object) -> Bool { (value as Cell<LDouble> get() - correct as Cell<LDouble> get()) abs() < precision }
-		CompareConstraint new(this, this correct, f, ComparisonType Within)
+		CompareConstraint new(this, Cell<LDouble> new(this correct as Cell<LDouble> get()), f, ComparisonType Within)
 	}
 	test: override func (value: Object) -> Bool {
 		comparer := this comparer

--- a/test/base/TextLiteralTest.ooc
+++ b/test/base/TextLiteralTest.ooc
@@ -104,8 +104,11 @@ TextLiteralTest: class extends Fixture {
 			expect(t"123one" toInt(), is equal to(123))
 			expect(t"101" toInt(), is equal to(101))
 			for (i in 1 .. 100)
-				for (j in 1 .. 100)
-					expect(Text new((i * j) toString()) toInt(), is equal to(i * j))
+				for (j in 1 .. 100) {
+					numberString := (i * j) toString()
+					expect(Text new(numberString) toInt(), is equal to(i * j))
+					numberString free()
+				}
 		})
 		this add("Convert to Int (base 16)", func {
 			expect(t"bad" toInt~inBase(16), is equal to(11 * 16 * 16 + 10 * 16 + 13))
@@ -139,8 +142,11 @@ TextLiteralTest: class extends Fixture {
 			expect(t"22.5" toFloat(), is equal to(22.5f) within(tolerance))
 			expect(t"123.763" toFloat(), is equal to(123.763f) within(tolerance))
 			for (i in 1 .. 100)
-				for (j in 1 .. 100)
-					expect(Text new((0.5f * i * j) toString()) toFloat(), is equal to(0.5f * i * j) within(tolerance))
+				for (j in 1 .. 100) {
+					numberString := (0.5f * i * j) toString()
+					expect(Text new(numberString) toFloat(), is equal to(0.5f * i * j) within(tolerance))
+					numberString free()
+				}
 		})
 		this add("Convert to Float (scientific notation)", func {
 			tolerance := 0.001f


### PR DESCRIPTION
Base class for Constraints now calls `free` on its child.
Fixed memory issues related to cell ownership.
@marcusnaslund 