### PR TITLE
RasterCanvas now use InterpolationMode when rescaling

### DIFF
--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -43,7 +43,7 @@ BgrRasterCanvas: class extends RasterCanvas {
 		if (this target size == bgr size && this target stride == bgr stride && source == destination && source size == bgr size && source leftTop x == 0 && source leftTop y == 0)
 			memcpy(this target buffer pointer, bgr buffer pointer, this target stride * this target height)
 		else
-			RasterCanvas resizeNearestNeighbour(bgr buffer pointer as ColorBgr*, this target buffer pointer as ColorBgr*, source, destination, bgr stride, this target stride, this target bytesPerPixel)
+			this _resizePacked(bgr buffer pointer as ColorBgr*, this target buffer pointer as ColorBgr*, source, destination, bgr stride, this target stride, this target bytesPerPixel)
 		if (bgr != image)
 			bgr referenceCount decrease()
 	}

--- a/source/draw/RasterCanvas.ooc
+++ b/source/draw/RasterCanvas.ooc
@@ -71,7 +71,13 @@ RasterCanvas: abstract class extends Canvas {
 	_map: func (point: IntPoint2D) -> IntPoint2D {
 		point + this _size / 2
 	}
-	resizeNearestNeighbour: static func <T> (sourceBuffer, resultBuffer: T*, sourceBox, resultBox: IntBox2D, sourceStride, resultStride, bytesPerPixel: Int) {
+	_resizePacked: func <T> (sourceBuffer, resultBuffer: T*, sourceBox, resultBox: IntBox2D, sourceStride, resultStride, bytesPerPixel: Int) {
+		if (this interpolationMode == InterpolationMode Fast)
+			This _resizeNearestNeighbour(sourceBuffer, resultBuffer, sourceBox, resultBox, sourceStride, resultStride, bytesPerPixel)
+		else
+			This _resizeBilinear(sourceBuffer, resultBuffer, sourceBox, resultBox, sourceStride, resultStride, bytesPerPixel)
+	}
+	_resizeNearestNeighbour: static func <T> (sourceBuffer, resultBuffer: T*, sourceBox, resultBox: IntBox2D, sourceStride, resultStride, bytesPerPixel: Int) {
 		(resultWidth, resultHeight) := (resultBox size x, resultBox size y)
 		(sourceWidth, sourceHeight) := (sourceBox size x, sourceBox size y)
 		sourceStride /= bytesPerPixel
@@ -88,7 +94,7 @@ RasterCanvas: abstract class extends Canvas {
 			}
 		}
 	}
-	resizeBilinear: static func <T> (sourceBuffer, resultBuffer: T*, sourceBox, resultBox: IntBox2D, sourceStride, resultStride, bytesPerPixel: Int) {
+	_resizeBilinear: static func <T> (sourceBuffer, resultBuffer: T*, sourceBox, resultBox: IntBox2D, sourceStride, resultStride, bytesPerPixel: Int) {
 		(resultWidth, resultHeight) := (resultBox size x, resultBox size y)
 		(sourceWidth, sourceHeight) := (sourceBox size x, sourceBox size y)
 		(sourceStartColumn, sourceStartRow) := (sourceBox leftTop x, sourceBox leftTop y)

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -68,8 +68,8 @@ RasterMonochrome: class extends RasterPacked {
 		else {
 			result = This new(size)
 			match (method) {
-				case InterpolationMode Smooth => RasterCanvas resizeBilinear(this buffer pointer as ColorMonochrome*, result buffer pointer as ColorMonochrome*, IntBox2D new(this size), IntBox2D new(result size), this stride, result stride, this bytesPerPixel)
-				case => RasterCanvas resizeNearestNeighbour(this buffer pointer as ColorMonochrome*, result buffer pointer as ColorMonochrome*, IntBox2D new(this size), IntBox2D new(result size), this stride, result stride, this bytesPerPixel)
+				case InterpolationMode Smooth => RasterCanvas _resizeBilinear(this buffer pointer as ColorMonochrome*, result buffer pointer as ColorMonochrome*, IntBox2D new(this size), IntBox2D new(result size), this stride, result stride, this bytesPerPixel)
+				case => RasterCanvas _resizeNearestNeighbour(this buffer pointer as ColorMonochrome*, result buffer pointer as ColorMonochrome*, IntBox2D new(this size), IntBox2D new(result size), this stride, result stride, this bytesPerPixel)
 			}
 		}
 		result


### PR DESCRIPTION
Created a generic method to select correct rescaling function according to `interpolation mode` set in `RasterCanvas`. 
Made functions implementing the pixel operations private.
@marcusnaslund ready