### PR TITLE
Corrected buffer ownership in RasterMonochrome open

### DIFF
--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -114,7 +114,8 @@ RasterMonochrome: class extends RasterPacked {
 		x, y, imageComponents: Int
 		requiredComponents := 1
 		data := StbImage load(filename, x&, y&, imageComponents&, requiredComponents)
-		This new(ByteBuffer new(data as UInt8*, x * y * requiredComponents), IntVector2D new(x, y))
+		buffer := ByteBuffer new(data as UInt8*, x * y * requiredComponents, true)
+		This new(buffer, IntVector2D new(x, y))
 	}
 	convertFrom: static func (original: RasterImage) -> This {
 		result: This


### PR DESCRIPTION
Same change as for `RasterBgra`
@marcusnaslund can you test ?