### PR TITLE
Cleaned up fancy backtrace loading

### DIFF
--- a/source/sdk/lang/Backtrace.ooc
+++ b/source/sdk/lang/Backtrace.ooc
@@ -1,5 +1,4 @@
 import os/[Env, Dynlib, ShellUtils]
-import io/[File, StringReader]
 import structs/[ArrayList, List]
 import lang/internals/mangling
 
@@ -7,7 +6,7 @@ BacktraceHandler: class {
 	BACKTRACE_LENGTH := static 128
 	WARNED_ABOUT_FALLBACK := static false
 	instance: static This
-	lib: Dynlib
+	lib: Dynlib = null
 	fancyBacktrace: Pointer
 	fancyBacktraceSymbols: Pointer
 	fancyBacktraceWithContext: Pointer // windows-only
@@ -86,25 +85,7 @@ BacktraceHandler: class {
 			raw? = true
 		}
 
-		// try to load it from the system's search path
-		// includes the current directory on Windows
-		lib = Dynlib load("fancy_backtrace")
-
-		if (!lib) {
-			// try to load it from the current directory?
-			// makes the magic work on Linux
-			lib = Dynlib load("./fancy_backtrace")
-		}
-
-		if (!lib) {
-			// try to find in rock's path, if rock is there.
-			rockPath := ShellUtils findExecutable("rock")
-			if (rockPath) {
-				binPath := rockPath getParent()
-				path := File join(binPath, "fancy_backtrace")
-				lib = Dynlib load(path)
-			}
-		}
+		this lib = Dynlib load("fancy_backtrace") ?? Dynlib load("./fancy_backtrace")
 
 		if (lib) {
 			_initFuncs()


### PR DESCRIPTION
I really dig that `??` operator.

The third case is not needed since we don't compile the fancy backtrace that way, and this helps us to move out `sdk/io`.

@sebastianbaginski ?