### PR TITLE
Fixed recycling of EGLBgra images.

### DIFF
--- a/source/draw/gpu/opengl/AndroidContext.ooc
+++ b/source/draw/gpu/opengl/AndroidContext.ooc
@@ -45,7 +45,6 @@ AndroidContext: class extends OpenGLContext {
 				graphicBufferImage := rasterImage as GraphicBufferYuv420Semiplanar
 				rgba := graphicBufferImage toRgba(this)
 				result = this unpackBgraToYuv420Semiplanar(rgba, rasterImage size, graphicBufferImage uvPadding % graphicBufferImage stride)
-				rgba free()
 			}
 			else
 				result = super(rasterImage)


### PR DESCRIPTION
* When `EGLBgra` images are created from the buffer of a `GraphicBufferYuv420Semiplanar`, they are kept as a member for the instance for future use. 
* When `GraphicBufferYuv420Semiplanar` is freed, the `EGLBgra` is recycled.
* When creating a new `GraphicBufferYuv420Semiplanar`, if the `GraphicBuffer` matches a recycled `EGLBgra` image, the `EGLBgra` can be reused.
* Extreme performance increase

@sebastianbaginski peer