### PR TITLE
Added implicit toText() for Int, UInt, Float, Double

### DIFF
--- a/source/base/Text.ooc
+++ b/source/base/Text.ooc
@@ -53,6 +53,30 @@ Text: cover {
 	operator != (other: String) -> Bool { !(this == other) }
 	operator != (other: This) -> Bool { !(this == other) }
 	operator + (other: This) -> This { This new(this _buffer + other _buffer) }
+	operator + (other: Int) -> This {
+		converted := other toString()
+		result := this + This new(converted)
+		converted free()
+		result
+	}
+	operator + (other: UInt) -> This {
+		converted := other toString()
+		result := this + This new(converted)
+		converted free()
+		result
+	}
+	operator + (other: Float) -> This {
+		converted := other toString()
+		result := this + This new(converted)
+		converted free()
+		result
+	}
+	operator + (other: Double) -> This {
+		converted := other toString()
+		result := this + This new(converted)
+		converted free()
+		result
+	}
 	beginsWith: func (other: This) -> Bool { this slice(0, Int minimum(other count, this count)) == other }
 	beginsWith: func ~string (other: String) -> Bool { this beginsWith(This new(other)) }
 	beginsWith: func ~character (character: Char) -> Bool {

--- a/source/base/Text.ooc
+++ b/source/base/Text.ooc
@@ -53,18 +53,10 @@ Text: cover {
 	operator != (other: String) -> Bool { !(this == other) }
 	operator != (other: This) -> Bool { !(this == other) }
 	operator + (other: This) -> This { This new(this _buffer + other _buffer) }
-	operator + (other: Int) -> This {
-		this + other toText() take()
-	}
-	operator + (other: UInt) -> This {
-		this + other toText()
-	}
-	operator + (other: Float) -> This {
-		this + other toText() take()
-	}
-	operator + (other: Double) -> This {
-		this + other toText()
-	}
+	operator + (other: Int) -> This { this + other toText() }
+	operator + (other: UInt) -> This { this + other toText() }
+	operator + (other: Float) -> This { this + other toText() }
+	operator + (other: Double) -> This { this + other toText() }
 	beginsWith: func (other: This) -> Bool { this slice(0, Int minimum(other count, this count)) == other }
 	beginsWith: func ~string (other: String) -> Bool { this beginsWith(This new(other)) }
 	beginsWith: func ~character (character: Char) -> Bool {
@@ -335,7 +327,10 @@ extend Int {
 
 extend UInt {
 	toText: func -> Text {
-		Text new(this toString())
+		string := this toString()
+		result := Text new(string) copy()
+		string free()
+		result
 	}
 }
 
@@ -350,6 +345,9 @@ extend Float {
 
 extend Double {
 	toText: func -> Text {
-		Text new(this toString())
+		string := this toString()
+		result := Text new(string) copy()
+		string free()
+		result
 	}
 }

--- a/source/base/Text.ooc
+++ b/source/base/Text.ooc
@@ -54,28 +54,16 @@ Text: cover {
 	operator != (other: This) -> Bool { !(this == other) }
 	operator + (other: This) -> This { This new(this _buffer + other _buffer) }
 	operator + (other: Int) -> This {
-		converted := other toString()
-		result := this + This new(converted)
-		converted free()
-		result
+		this + other toText() take()
 	}
 	operator + (other: UInt) -> This {
-		converted := other toString()
-		result := this + This new(converted)
-		converted free()
-		result
+		this + other toText()
 	}
 	operator + (other: Float) -> This {
-		converted := other toString()
-		result := this + This new(converted)
-		converted free()
-		result
+		this + other toText() take()
 	}
 	operator + (other: Double) -> This {
-		converted := other toString()
-		result := this + This new(converted)
-		converted free()
-		result
+		this + other toText()
 	}
 	beginsWith: func (other: This) -> Bool { this slice(0, Int minimum(other count, this count)) == other }
 	beginsWith: func ~string (other: String) -> Bool { this beginsWith(This new(other)) }
@@ -335,3 +323,33 @@ makeTextLiteral: func (str: CString, strLen: Int) -> Text { Text new(str, strLen
 operator == (left: String, right: Text) -> Bool { Text new(left) == right }
 operator != (left: String, right: Text) -> Bool { !(left == right) }
 operator []= (left: TextBuffer, range: Range, right: Text) { right _buffer copyTo(left slice(range min, range count)) }
+
+extend Int {
+	toText: func -> Text {
+		string := this toString()
+		result := Text new(string) copy()
+		string free()
+		result
+	}
+}
+
+extend UInt {
+	toText: func -> Text {
+		Text new(this toString())
+	}
+}
+
+extend Float {
+	toText: func -> Text {
+		string := this toString()
+		result := Text new(string) copy()
+		string free()
+		result
+	}
+}
+
+extend Double {
+	toText: func -> Text {
+		Text new(this toString())
+	}
+}

--- a/test/base/TextTest.ooc
+++ b/test/base/TextTest.ooc
@@ -5,7 +5,7 @@ import math
 
 TextTest: class extends Fixture {
 	init: func {
-		super("Text")
+		super("Text")/*
 		this add("constructors", func {
 			text := Text new(c"test string", 5)
 			string := text give() toString()
@@ -225,7 +225,7 @@ TextTest: class extends Fixture {
 			expect(text == t"04")
 			text = t"%s %s %i %i" format("test", "number", 0, 1)
 			expect(text == t"test number 0 1")
-		})
+		})*/
 		this add("implicit toText", func {
 			one := t"123" + 456 + 7.89f
 			expect(one == t"1234567.89")
@@ -233,6 +233,9 @@ TextTest: class extends Fixture {
 			expect(two == t"123.456.789")
 			three := t"1" + 2 + t"3" + 4
 			expect(three == t"1234")
+			//one println()
+			//two println()
+			//three println()
 		})
 	}
 }

--- a/test/base/TextTest.ooc
+++ b/test/base/TextTest.ooc
@@ -226,6 +226,14 @@ TextTest: class extends Fixture {
 			text = t"%s %s %i %i" format("test", "number", 0, 1)
 			expect(text == t"test number 0 1")
 		})
+		this add("implicit toText", func {
+			one := t"123" + 456 + 7.89f
+			expect(one == t"1234567.89")
+			two := Text new("12") + 3.45f + 6.78 + 9
+			expect(two == t"123.456.789")
+			three := t"1" + 2 + t"3" + 4
+			expect(three == t"1234")
+		})
 	}
 }
 

--- a/test/base/TextTest.ooc
+++ b/test/base/TextTest.ooc
@@ -5,7 +5,7 @@ import math
 
 TextTest: class extends Fixture {
 	init: func {
-		super("Text")/*
+		super("Text")
 		this add("constructors", func {
 			text := Text new(c"test string", 5)
 			string := text give() toString()
@@ -225,17 +225,17 @@ TextTest: class extends Fixture {
 			expect(text == t"04")
 			text = t"%s %s %i %i" format("test", "number", 0, 1)
 			expect(text == t"test number 0 1")
-		})*/
+		})
 		this add("implicit toText", func {
 			one := t"123" + 456 + 7.89f
 			expect(one == t"1234567.89")
-			two := Text new("12") + 3.45f + 6.78 + 9
+			two := (Text new("12") + 3.45f + 6.78 + 9U) take()
 			expect(two == t"123.456.789")
-			three := t"1" + 2 + t"3" + 4
-			expect(three == t"1234")
-			//one println()
-			//two println()
-			//three println()
+			three := t"1" + 2 + t"3" + 4 + 5.67f
+			expect(three == t"12345.67")
+			four := two + 0
+			expect(four == two + t"0")
+			two free()
 		})
 	}
 }


### PR DESCRIPTION
Fixes #681 (no point in adding implicit `toString` anymore)

Creates invalid memory read/writes right now because of bugs in `Text print()`, so waiting on that.