### PR TITLE
Removed hard coded exception function name from Array.h

### DIFF
--- a/source/sdk/lang/Array.h
+++ b/source/sdk/lang/Array.h
@@ -15,9 +15,9 @@
 
 #if defined(safe)
 #define _lang_array__Array_get(array, index, type) ( \
-    ((type*) array.data)[(index < 0 || index >= array.length) ? lang_Exception__Exception_throw((lang_Exception__Exception *) lang_Exception__OutOfBoundsException_new_noOrigin(index, array.length)), -1 : index])
+    ((type*) array.data)[(index < 0 || index >= array.length) ? kean_lang_exception_outOfBoundsException_new(index, array.length), -1 : index])
 #define _lang_array__Array_set(array, index, type, value) \
-    (((type*) array.data)[(index < 0 || index >= array.length) ? lang_Exception__Exception_throw((lang_Exception__Exception *) lang_Exception__OutOfBoundsException_new_noOrigin(index, array.length)), -1 : index] = value)
+    (((type*) array.data)[(index < 0 || index >= array.length) ? kean_lang_exception_outOfBoundsException_new(index, array.length), -1 : index] = value)
 #else
 #define _lang_array__Array_get(array, index, type) ( \
     ((type*) array.data)[index])

--- a/source/sdk/lang/Exception.ooc
+++ b/source/sdk/lang/Exception.ooc
@@ -203,6 +203,9 @@ OutOfBoundsException: class extends Exception {
 	init: func ~noOrigin (accessOffset, elementLength: SizeT) {
 		message = "Trying to access an element at offset %d, but size is only %d!" format(accessOffset, elementLength)
 	}
+	kean_lang_exception_outOfBoundsException_new: static unmangled func (accessOffset, elementLength: SizeT) -> This {
+		This new(accessOffset, elementLength)
+	}
 }
 
 OutOfMemoryException: class extends Exception {


### PR DESCRIPTION
This gets rid of hard-coded mangled function name from Array.h and use our friendly name instead. Now will be easier to move Exception.ooc to another folder.