### PR TITLE
Fixed out of bounds bug in TextBuilder free method

### DIFF
--- a/source/base/TextBuilder.ooc
+++ b/source/base/TextBuilder.ooc
@@ -40,7 +40,7 @@ TextBuilder: class {
 		this append(original)
 	}
 	free: func {
-		for (i in 0 .. this count)
+		for (i in 0 .. this _data count)
 			this _data[i] free(Owner Receiver)
 		this _data free()
 		super()


### PR DESCRIPTION
`this count` returns total number of characters. Usually more than total number of text components...
@marcusnaslund 