### PR TITLE
Added missing canvas subclasses

### DIFF
--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -23,6 +23,20 @@ import RasterBgr
 import StbImage
 import Image
 import Color
+import Canvas, RasterCanvas
+
+RasterUvCanvas: class extends RasterCanvas {
+	target ::= this _target as RasterUv
+	init: func (image: RasterUv) { super(image) }
+	_drawPoint: override func (x, y: Int) {
+		position := this _map(IntPoint2D new(x, y))
+		if (this target isValidIn(position x, position y)) {
+			colorYuv := this pen color toYuv()
+			colorUv := ColorUv new(colorYuv u, colorYuv v)
+			this target[position x, position y] = this target[position x, position y] blend(this pen alphaAsFloat, colorUv)
+		}
+	}
+}
 
 RasterUv: class extends RasterPacked {
 	bytesPerPixel ::= 2
@@ -142,4 +156,5 @@ RasterUv: class extends RasterPacked {
 
 	operator [] (x, y: Int) -> ColorUv { this isValidIn(x, y) ? ((this buffer pointer + y * this stride) as ColorUv* + x)@ : ColorUv new(0, 0) }
 	operator []= (x, y: Int, value: ColorUv) { ((this buffer pointer + y * this stride) as ColorUv* + x)@ = value }
+	_createCanvas: override func -> Canvas { RasterUvCanvas new(this) }
 }

--- a/source/draw/RasterYuv420Planar.ooc
+++ b/source/draw/RasterYuv420Planar.ooc
@@ -23,6 +23,17 @@ import RasterYuvPlanar
 import RasterMonochrome
 import Image
 import Color
+import Canvas, RasterCanvas
+
+RasterYuv420PlanarCanvas: class extends RasterCanvas {
+	target ::= this _target as RasterYuv420Planar
+	init: func (image: RasterYuv420Planar) { super(image) }
+	_drawPoint: override func (x, y: Int) {
+		position := this _map(IntPoint2D new(x, y))
+		if (this target isValidIn(position x, position y))
+			this target[position x, position y] = this target[position x, position y] blend(this pen alphaAsFloat, this pen color toYuv())
+	}
+}
 
 RasterYuv420Planar: class extends RasterYuvPlanar {
 	stride ::= this _y stride
@@ -148,4 +159,5 @@ RasterYuv420Planar: class extends RasterYuvPlanar {
 		this u[x / 2, y / 2] = ColorMonochrome new(value u)
 		this v[x / 2, y / 2] = ColorMonochrome new(value v)
 	}
+	_createCanvas: override func -> Canvas { RasterYuv420PlanarCanvas new(this) }
 }

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -32,7 +32,7 @@ import io/Reader
 import io/FileWriter
 import Canvas, RasterCanvas
 
-RasterYuv420Canvas: class extends RasterCanvas {
+RasterYuv420SemiplanarCanvas: class extends RasterCanvas {
 	target ::= this _target as RasterYuv420Semiplanar
 	init: func (image: RasterYuv420Semiplanar) { super(image) }
 	_drawPoint: override func (x, y: Int) {
@@ -257,7 +257,7 @@ RasterYuv420Semiplanar: class extends RasterYuvSemiplanar {
 		fileWriter write(this uv buffer pointer as Char*, this uv buffer size)
 		fileWriter close()
 	}
-	_createCanvas: override func -> Canvas { RasterYuv420Canvas new(this) }
+	_createCanvas: override func -> Canvas { RasterYuv420SemiplanarCanvas new(this) }
 	kean_draw_rasterYuv420Semiplanar_new: static unmangled func (width, height, stride: Int, monochromeData, uvData: Void*) -> This {
 		result := This new(IntVector2D new(width, height), stride)
 		memcpy(result uv buffer pointer, uvData, (height / 2) * stride)

--- a/source/draw/RasterYuv422Semipacked.ooc
+++ b/source/draw/RasterYuv422Semipacked.ooc
@@ -28,6 +28,17 @@ import io/File
 import io/FileReader
 import io/Reader
 import io/FileWriter
+import Canvas, RasterCanvas
+
+RasterYuv422SemipackedCanvas: class extends RasterCanvas {
+	target ::= this _target as RasterYuv422Semipacked
+	init: func (image: RasterYuv422Semipacked) { super(image) }
+	_drawPoint: override func (x, y: Int) {
+		position := this _map(IntPoint2D new(x, y))
+		if (this target isValidIn(position x, position y))
+			this target[position x, position y] = this target[position x, position y] blend(this pen alphaAsFloat, this pen color toYuv())
+	}
+}
 
 RasterYuv422Semipacked: class extends RasterPacked {
 	bytesPerPixel ::= 2
@@ -101,6 +112,7 @@ RasterYuv422Semipacked: class extends RasterPacked {
 		fileWriter write(this buffer pointer as Char*, this buffer size)
 		fileWriter close()
 	}
+	_createCanvas: override func -> Canvas { RasterYuv422SemipackedCanvas new(this) }
 	convertFrom: static func (original: RasterImage) -> This {
 		result: This
 		if (original instanceOf?(This))


### PR DESCRIPTION
Added `yuv422planar`, `uv`, `yuv420packed` canvas subclasses. Renamed `RasterYuv420Canvas` to `RasterYuv420SemiplanarCanvas`.
@emilwestergren peer review