### PR TITLE
Fixed save in RasterUv

### DIFF
--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -104,16 +104,15 @@ RasterUv: class extends RasterPacked {
 		}
 	}
 	open: static func (filename: String) -> This {
-		//FIXME: Is it neccessary to create a RasterBgr here?
 		rasterBgr := RasterBgr open(filename)
 		result := This convertFrom(rasterBgr)
 		rasterBgr referenceCount decrease()
 		result
 	}
 	save: override func (filename: String) -> Int {
-		bgr := RasterBgr new(this buffer, this size)
+		bgr := RasterBgr convertFrom(this)
 		result := bgr save(filename)
-		bgr free()
+		bgr referenceCount decrease()
 		result
 	}
 	convertFrom: static func (original: RasterImage) -> This {

--- a/test/draw/ImageFileTest.ooc
+++ b/test/draw/ImageFileTest.ooc
@@ -196,6 +196,16 @@ ImageFileTest: class extends Fixture {
 			expect(This _fileExists(destination))
 			semiplanar free()
 		})
+		this add("Open and save RasterUv", func {
+			source := "test/draw/input/Flower.png"
+			destination := "test/draw/output/RasterUv.png"
+			uv := RasterUv open(source)
+			uv save(destination)
+			expect(This _fileExists(destination))
+			destination free()
+			source free()
+			uv referenceCount decrease()
+		})
 		this add("save to bin", func {
 			source := "test/draw/input/Flower.png"
 			destination := "test/draw/output/Flower.bin"


### PR DESCRIPTION
Fixes https://github.com/cogneco/ooc-kean/issues/1001
Added test case for RasterUv load/save

RasterBgr seems to be needed when opening and saving, as without it, it seems like `b` and `g` channels are used to fill the `u` and `v` components of the image without converting `rgb` to `yuv`.

@marcusnaslund 