### PR TITLE
Corrected ColorMonochrome constructor with 32 and 64 bit unsigned parameters

### DIFF
--- a/source/draw/Color.ooc
+++ b/source/draw/Color.ooc
@@ -25,6 +25,10 @@ ColorMonochrome: cover {
 	normalized ::= this y as Float / 255
 	init: func@ (=y)
 	init: func@ ~default { this init(0) }
+	init: func@ ~uint (i: UInt) { this init(i as UInt8) }
+	init: func@ ~uint16 (i: UInt16) { this init(i as UInt8) }
+	init: func@ ~uint32 (i: UInt32) { this init(i as UInt8) }
+	init: func@ ~uint64 (i: UInt64) { this init(i as UInt8) }
 	init: func@ ~int (i: Int) { this init(i as UInt8) }
 	init: func@ ~float (f: Float) { this init(f*255.0f clamp(0.0f, 255.0f) as UInt8) }
 	init: func@ ~double (d: Double) { this init(d*255.0f clamp(0.0f, 255.0f) as UInt8) }

--- a/test/draw/RasterMonochromeTest.ooc
+++ b/test/draw/RasterMonochromeTest.ooc
@@ -98,6 +98,19 @@ RasterMonochromeTest: class extends Fixture {
 			image referenceCount decrease()
 			image2 referenceCount decrease()
 		})
+		this add("color monochrome from unsigned types", func {
+			image := RasterMonochrome new(IntVector2D new(10, 10))
+			value: UInt = 128
+			value32: UInt32 = 128
+			value64: UInt64 = 128
+			image[0, 0] = ColorMonochrome new(value32)
+			image[0, 1] = ColorMonochrome new(value64)
+			image[0, 2] = ColorMonochrome new(value)
+			expect(image[0, 0] y as Int, is equal to(value32 as Int))
+			expect(image[0, 1] y as Int, is equal to(value64 as Int))
+			expect(image[0, 2] y as Int, is equal to(value as Int))
+			image referenceCount decrease()
+		})
 		/*this add("distance, convertFrom RasterBgra", func {
 			source := this sourceFlower
 			output := "test/draw/output/RasterBgrToMonochrome.png"


### PR DESCRIPTION
Test case added.
@marcusnaslund 

Bug was caused by rock picking the `Float` version of constructor for unsigned parameters.