### PR TITLE
Moved logic from FloatRotation3D to Quaternion and fixed formula

### DIFF
--- a/source/geometry/FloatRotation3D.ooc
+++ b/source/geometry/FloatRotation3D.ooc
@@ -40,10 +40,7 @@ FloatRotation3D: cover {
 	sphericalLinearInterpolation: func (other: This, factor: Float) -> This {
 		This new(this _quaternion sphericalLinearInterpolation(other _quaternion, factor))
 	}
-	angle: func (other: This) -> Float {
-		result := acos(Float absolute(this _quaternion dotProduct(other _quaternion))) as Float
-		result = result == result ? result : 0.0f
-	}
+	angle: func (other: This) -> Float { this _quaternion angle(other _quaternion) }
 	toString: func -> String { this _quaternion toString() }
 	kean_math_floatRotation3D_new: unmangled static func (quaternion: Quaternion) -> This { This new(quaternion) }
 }

--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -120,6 +120,11 @@ Quaternion: cover {
 	distance: func (other: This) -> Float {
 		(this - other) norm
 	}
+	angle: func (other: This) -> Float {
+		result := 2.0f * Float absolute(this dotProduct(other)) acos()
+		result = result == result ? result : 0.0f
+		result
+	}
 	rotationX: Float {
 		get {
 			result: Float

--- a/test/geometry/QuaternionTest.ooc
+++ b/test/geometry/QuaternionTest.ooc
@@ -100,6 +100,13 @@ QuaternionTest: class extends Fixture {
 			point2 := FloatPoint3D new(7.0f, 5.0f, 6.0f)
 			expect((quaternion * point1) distance(point2), is equal to(0.0f))
 		})
+		this add("angle", func {
+			direction := FloatPoint3D new(1.0f, 1.0f, 1.0f)
+			quaternion1 := Quaternion createRotation(Float toRadians(20.0f), direction)
+			quaternion2 := Quaternion createRotation(Float toRadians(45.0f), direction)
+			angle := Float toDegrees(quaternion1 angle(quaternion2))
+			expect(angle, is equal to(25.0f) within(tolerance))
+		})
 		this add("rotationDirectionRepresentation1", func {
 			angle := Float toRadians(30.0f)
 			direction := FloatPoint3D new(1.0f, 4.0f, 7.0f)


### PR DESCRIPTION
So, whilst moving the `angle` method from `FloatRotation3D` to `Quaternion` I also noticed that it was calculating the wrong results. Apparently there was a factor `2.0f` missing from the formula (See http://math.stackexchange.com/questions/90081/quaternion-distance). Additionally a test was missing for this particular function so it has passed by unnoticed for a while. This is now fixed.