### PR TITLE
Moved synchronization objects from Gles3Fence to OpenGLFence.

### DIFF
--- a/source/draw/gpu/opengl/backend/GLFence.ooc
+++ b/source/draw/gpu/opengl/backend/GLFence.ooc
@@ -17,21 +17,11 @@
 
 use ooc-base
 use ooc-geometry
-import os/Time
-import threading/[Thread, Mutex, WaitCondition]
 
 version(!gpuOff) {
 GLFence: abstract class {
 	_backend: Pointer = null
-	_syncCondition := WaitCondition new()
-	_mutex := Mutex new()
-
 	init: func
-	free: override func {
-		this _mutex free()
-		this _syncCondition free()
-		super()
-	}
 	clientWait: abstract func (timeout: UInt64 = ULLONG_MAX)
 	wait: abstract func
 	sync: abstract func


### PR DESCRIPTION
Moved Mutex and WaitCondition up an abstraction level. Probably shouldn't be here in the long term but it's nice to be able to begin waiting on a gpu fence even though it has not been created yet on the GPU.

@sebastianbaginski peer