### PR TITLE
Wrote a test for Synchronized

### DIFF
--- a/source/base/Synchronized.ooc
+++ b/source/base/Synchronized.ooc
@@ -14,6 +14,7 @@
 * You should have received a copy of the GNU Lesser General Public License
 * along with this software. If not, see <http://www.gnu.org/licenses/>.
 */
+
 import threading/Mutex
 
 Synchronized: class {


### PR DESCRIPTION
Not a great test, but better than one that does nothing.
Fixes #886 

It's basically just a `Mutex` test, but then `Synchronized` is basically just a `Mutex` wrapper. Its existence would make more sense if we had interfaces, but, alright, it's there and it's used - so it deserves a real test.