### PR TITLE
Added constructor from RasterImage to RasterBgr

### DIFF
--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -52,7 +52,8 @@ RasterBgr: class extends RasterPacked {
 	init: func ~allocateStride (size: IntVector2D, stride: UInt) { super(size, stride) }
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D) { this init(buffer, size, this bytesPerPixel * size x) }
-	init: func ~fromRasterImage (original: This) { super(original) }
+	init: func ~fromRasterBgr (original: This) { super(original) }
+	init: func ~fromRasterImage (original: RasterImage) { super(original) }
 	create: func (size: IntVector2D) -> Image { This new(size) }
 	copy: func -> This { This new(this) }
 	apply: func ~bgr (action: Func(ColorBgr)) {
@@ -142,9 +143,7 @@ RasterBgr: class extends RasterPacked {
 		if (original instanceOf?(This))
 			result = (original as This) copy()
 		else {
-			result = This new(original size)
-			//TODO make it work via constructor
-			result coordinateSystem = original coordinateSystem
+			result = This new(original)
 			row := result buffer pointer as Long
 			rowLength := result size x
 			rowEnd := row as ColorBgr* + rowLength


### PR DESCRIPTION
Removes TODO and explicit coordinate system assignment from `convertFrom` in `RasterBgr`.
@marcusnaslund 