### PR TITLE
Added functions to create rotations from euler angles.

### DIFF
--- a/source/geometry/FloatRotation3D.ooc
+++ b/source/geometry/FloatRotation3D.ooc
@@ -37,6 +37,9 @@ FloatRotation3D: cover {
 	createRotationX: static func (angle: Float) -> This { This new(Quaternion createRotationX(angle)) }
 	createRotationY: static func (angle: Float) -> This { This new(Quaternion createRotationY(angle)) }
 	createRotationZ: static func (angle: Float) -> This { This new(Quaternion createRotationZ(angle)) }
+	createFromEulerAngles: static func (rotationX, rotationY, rotationZ: Float) -> This {
+		This new(Quaternion createFromEulerAngles(rotationX, rotationY, rotationZ))
+	}
 	sphericalLinearInterpolation: func (other: This, factor: Float) -> This {
 		This new(this _quaternion sphericalLinearInterpolation(other _quaternion, factor))
 	}

--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -51,6 +51,9 @@ Quaternion: cover {
 	init: func@ ~floats (w, x, y, z: Float) { this init(w, FloatPoint3D new(x, y, z)) }
 	init: func@ ~default { this init(0, 0, 0, 0) }
 	init: func@ ~floatArray (source: Float[]) { this init(source[0], source[1], source[2], source[3]) }
+	createFromEulerAngles: static func (rotationX, rotationY, rotationZ: Float) -> This {
+		This createRotationZ(rotationZ) * This createRotationY(rotationY) * This createRotationX(rotationX)
+	}
 	init: func@ ~fromFloatTransform3D (transform: FloatTransform3D) {
 		// Farrell, Jay. A. Computation of the Quaternion from a Rotation Matrix.
 		// http://www.ee.ucr.edu/~farrell/AidedNavigation/D_App_Quaternions/Rot2Quat.pdf
@@ -125,6 +128,7 @@ Quaternion: cover {
 		result = result == result ? result : 0.0f
 		result
 	}
+	// NOTE: Separation into parts assumes order of application X -> Y -> Z
 	rotationX: Float {
 		get {
 			result: Float

--- a/test/geometry/FloatRotation3DTest.ooc
+++ b/test/geometry/FloatRotation3DTest.ooc
@@ -19,8 +19,6 @@ use ooc-geometry
 use ooc-unit
 import math
 
-//TODO: Missing properties: x, y, z. Missing methods: createRotationX, createRotationY, createRotationZ
-
 FloatRotation3DTest: class extends Fixture {
 	quaternion0 := Quaternion new(33.0f, 10.0f, -12.0f, 54.5f)
 	quaternion1 := Quaternion new(10.0f, 17.0f, -10.0f, 14.5f)
@@ -48,12 +46,12 @@ FloatRotation3DTest: class extends Fixture {
 			rotation2 := FloatRotation3D new(this quaternion2)
 			rotation3 := FloatRotation3D new(this quaternion3)
 			rotation4 := FloatRotation3D new(this quaternion4)
-			
+
 			expect(rotation1 == rotation4)
 			expect(rotation2 == rotation3, is false)
 			expect(rotation3 != rotation4)
 			expect(rotation1 != rotation4, is false)
-			
+
 			expect(rotation0 * rotation1 == rotation3)
 		})
 		this add("normalized", func {

--- a/test/geometry/FloatRotation3DTest.ooc
+++ b/test/geometry/FloatRotation3DTest.ooc
@@ -86,6 +86,15 @@ FloatRotation3DTest: class extends Fixture {
 			angle := Float toDegrees(rotationA angle(rotationB))
 			expect(angle, is equal to(25.0f) within(tolerance))
 		})
+		this add("euler angles conversion", func {
+			x := 0.1f
+			y := 0.23f
+			z := 0.04f
+			rotation := FloatRotation3D createFromEulerAngles(x, y, z)
+			expect(x, is equal to(rotation x) within(tolerance))
+			expect(y, is equal to(rotation y) within(tolerance))
+			expect(z, is equal to(rotation z) within(tolerance))
+		})
 	}
 }
 

--- a/test/geometry/QuaternionTest.ooc
+++ b/test/geometry/QuaternionTest.ooc
@@ -339,6 +339,15 @@ QuaternionTest: class extends Fixture {
 				weights add(1.0f)
 			expect(Quaternion weightedMean(quaternionList, weights) rotationZ, is equal to(-1.7f) within(0.001f))
 		})
+		this add("euler angles conversion", func {
+			x := 0.1f
+			y := 0.23f
+			z := 0.04f
+			quaternion := Quaternion createFromEulerAngles(x, y, z)
+			expect(x - quaternion rotationX, is equal to(0.0f) within(tolerance))
+			expect(y - quaternion rotationY, is equal to(0.0f) within(tolerance))
+			expect(z - quaternion rotationZ, is equal to(0.0f) within(tolerance))
+		})
 	}
 }
 

--- a/test/geometry/QuaternionTest.ooc
+++ b/test/geometry/QuaternionTest.ooc
@@ -344,9 +344,9 @@ QuaternionTest: class extends Fixture {
 			y := 0.23f
 			z := 0.04f
 			quaternion := Quaternion createFromEulerAngles(x, y, z)
-			expect(x - quaternion rotationX, is equal to(0.0f) within(tolerance))
-			expect(y - quaternion rotationY, is equal to(0.0f) within(tolerance))
-			expect(z - quaternion rotationZ, is equal to(0.0f) within(tolerance))
+			expect(x, is equal to(quaternion rotationX) within(tolerance))
+			expect(y, is equal to(quaternion rotationY) within(tolerance))
+			expect(z, is equal to(quaternion rotationZ) within(tolerance))
 		})
 	}
 }


### PR DESCRIPTION
Also added note to clarify the order which rotations should be applied.
I tried making the 
`createFromEulerAngles: static func (...)`
functions like
`init: func@ ~fromEulerAngles (...)`
but it seems ooc doesn't like calling static functions from constructors.