### PR TITLE
No raw property in TextBuffer

### DIFF
--- a/source/sdk/TextBuffer.ooc
+++ b/source/sdk/TextBuffer.ooc
@@ -20,11 +20,6 @@ import OwnedBuffer
 
 TextBuffer: cover {
 	_backend: OwnedBuffer
-	raw: Char* { get {
-		result := this _backend pointer as Char*
-		this free(Owner Receiver)
-		result
-	}}
 	count: Int { get {
 		result := this _backend size
 		this free(Owner Receiver)
@@ -77,13 +72,13 @@ TextBuffer: cover {
 	toString: func -> String {
 		t := this take()
 		result := CharBuffer new()
-		result append(t raw, t count)
+		result append(t _backend pointer as Char*, t count)
 		this free(Owner Receiver)
 		String new(result)
 	}
-	operator [] (index: Int) -> Char { this raw[index] }
+	operator [] (index: Int) -> Char { (this _backend pointer as Char*)[index] }
 	operator [] (range: Range) -> This { this slice(range min, range max - range min) }
-	operator []= (index: Int, value: Char) { this raw[index] = value }
+	operator []= (index: Int, value: Char) { (this _backend pointer as Char*)[index] = value }
 	operator []= (range: Range, data: This) { data copyTo(this[range]) }
 	operator == (other: This) -> Bool {
 		result := this _backend == other _backend


### PR DESCRIPTION
`raw` no longer calls free
Fixes https://github.com/cogneco/ooc-kean/issues/1059
@marcusnaslund 