### PR TITLE
Added Text support in Cell toString

### DIFF
--- a/source/sdk/lang/types.ooc
+++ b/source/sdk/lang/types.ooc
@@ -127,6 +127,7 @@ Cell: class <T> {
 	}
 	toString: func -> String {
 		match (this val) {
+			case value: Text => value toString()
 			case value: Bool => value toString()
 			case value: Char => value toString()
 			case value: Int => value toString()


### PR DESCRIPTION
Fixes #689 

We can do this now. Allows us to use `is equal to` with `Text` without crashing the whole test.

@thomasfanell - peer review?