### PR TITLE
Automatically import math to all files

### DIFF
--- a/sdk.use
+++ b/sdk.use
@@ -14,6 +14,7 @@ Imports: lang/String
 Imports: lang/stdlib
 Imports: lang/types
 Imports: lang/VarArgs
+Imports: math
 Imports: Owner
 Imports: OwnedBuffer
 Imports: TextBuffer

--- a/source/base/TimeSpan.ooc
+++ b/source/base/TimeSpan.ooc
@@ -16,7 +16,6 @@
 */
 
 use ooc-base
-import math
 
 TimeSpan: cover {
 	_ticks: Int64 = 0

--- a/source/collections/Queue.ooc
+++ b/source/collections/Queue.ooc
@@ -1,5 +1,3 @@
-import math
-
 Queue: abstract class <T> {
 	_count := 0
 	count ::= this _count

--- a/source/collections/Vector2D.ooc
+++ b/source/collections/Vector2D.ooc
@@ -14,7 +14,6 @@
 * You should have received a copy of the GNU Lesser General Public License
 * along with this software. If not, see <http://www.gnu.org/licenses/>.
 */
-import math
 
 Vector2D: class <T> {
 	_backend: T*

--- a/source/draw/Color.ooc
+++ b/source/draw/Color.ooc
@@ -13,9 +13,9 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use ooc-base
 use ooc-geometry
-import math
 
 ColorMonochrome: cover {
 	y: UInt8

--- a/source/draw/FloatImage.ooc
+++ b/source/draw/FloatImage.ooc
@@ -1,5 +1,5 @@
-import math
 use ooc-geometry
+
 FloatImage : class {
 	// x = column
 	// y = row

--- a/source/draw/Image.ooc
+++ b/source/draw/Image.ooc
@@ -16,7 +16,6 @@
 
 use ooc-geometry
 use ooc-base
-import math
 import Canvas
 
 CoordinateSystem: enum {

--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -16,7 +16,6 @@
 
 use ooc-geometry
 use ooc-base
-import math
 import RasterPacked
 import RasterImage
 import StbImage

--- a/source/draw/RasterBgra.ooc
+++ b/source/draw/RasterBgra.ooc
@@ -16,7 +16,6 @@
 
 use ooc-geometry
 use ooc-base
-import math
 import RasterPacked
 import RasterImage
 import StbImage

--- a/source/draw/RasterCanvas.ooc
+++ b/source/draw/RasterCanvas.ooc
@@ -17,8 +17,10 @@
 use ooc-base
 use ooc-geometry
 use ooc-collections
-import math
-import Image, Canvas, Pen, RasterImage
+import Image
+import Canvas
+import Pen
+import RasterImage
 
 RasterCanvas: abstract class extends Canvas {
 	_target: RasterImage

--- a/source/draw/RasterImage.ooc
+++ b/source/draw/RasterImage.ooc
@@ -16,7 +16,6 @@
 
 use ooc-geometry
 use ooc-base
-import math
 import Image
 import RasterBgra, RasterMonochrome, RasterBgr
 import Color

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 use ooc-base
 use ooc-math
 use ooc-geometry

--- a/source/draw/RasterPacked.ooc
+++ b/source/draw/RasterPacked.ooc
@@ -17,8 +17,7 @@
 use ooc-geometry
 use ooc-base
 import io/File
-import ByteBuffer into ByteBuffer
-import math
+import ByteBuffer
 import StbImage
 import RasterImage
 import RasterBgra

--- a/source/draw/RasterPlanar.ooc
+++ b/source/draw/RasterPlanar.ooc
@@ -17,7 +17,6 @@
 use ooc-geometry
 use ooc-base
 import ByteBuffer into ByteBuffer
-import math
 import Image
 import RasterImage
 

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -16,7 +16,6 @@
 
 use ooc-geometry
 use ooc-base
-import math
 import RasterPacked
 import RasterImage
 import RasterBgr

--- a/source/draw/RasterYuv420Planar.ooc
+++ b/source/draw/RasterYuv420Planar.ooc
@@ -16,7 +16,6 @@
 
 use ooc-geometry
 use ooc-base
-import math
 import RasterPacked
 import RasterImage
 import RasterYuvPlanar

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -16,7 +16,6 @@
 
 use ooc-geometry
 use ooc-base
-import math
 import RasterPacked
 import RasterImage
 import RasterYuvSemiplanar

--- a/source/draw/RasterYuv422Semipacked.ooc
+++ b/source/draw/RasterYuv422Semipacked.ooc
@@ -16,7 +16,6 @@
 
 use ooc-geometry
 use ooc-base
-import math
 import RasterPacked
 import RasterImage
 import RasterMonochrome

--- a/source/draw/RasterYuvPlanar.ooc
+++ b/source/draw/RasterYuvPlanar.ooc
@@ -16,7 +16,6 @@
 
 use ooc-geometry
 use ooc-base
-import math
 import RasterPlanar
 import RasterPacked
 import RasterImage

--- a/source/draw/RasterYuvSemiplanar.ooc
+++ b/source/draw/RasterYuvSemiplanar.ooc
@@ -16,7 +16,6 @@
 
 use ooc-geometry
 use ooc-base
-import math
 import RasterPlanar
 import RasterPacked
 import RasterImage

--- a/source/draw/gpu/opengl/AndroidContext.ooc
+++ b/source/draw/gpu/opengl/AndroidContext.ooc
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use ooc-draw-gpu
 use ooc-collections
 use ooc-draw
@@ -20,7 +21,6 @@ use ooc-geometry
 use ooc-base
 import OpenGLContext, GraphicBuffer, GraphicBufferYuv420Semiplanar, EGLBgra, OpenGLBgra, OpenGLPacked, OpenGLMonochrome, OpenGLUv, OpenGLMap
 import threading/Thread
-import math
 
 version(!gpuOff) {
 AndroidContext: class extends OpenGLContext {

--- a/source/draw/gpu/opengl/GraphicBuffer.ooc
+++ b/source/draw/gpu/opengl/GraphicBuffer.ooc
@@ -13,11 +13,11 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use ooc-geometry
 use ooc-base
 use ooc-draw
 use ooc-draw-gpu
-import math
 
 version(!gpuOff) {
 GraphicBufferFormat: enum {

--- a/source/draw/gpu/opengl/GraphicBufferYuv420Semiplanar.ooc
+++ b/source/draw/gpu/opengl/GraphicBufferYuv420Semiplanar.ooc
@@ -15,7 +15,6 @@
 * along with This software. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import math
 use ooc-draw
 use ooc-geometry
 use ooc-base

--- a/source/geometry/FloatBox2D.ooc
+++ b/source/geometry/FloatBox2D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 use ooc-math
 import FloatPoint2D
 import FloatVector2D

--- a/source/geometry/FloatConvexHull2D.ooc
+++ b/source/geometry/FloatConvexHull2D.ooc
@@ -15,7 +15,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use ooc-collections
-import math
 use ooc-math
 import FloatPoint2D
 import FloatBox2D

--- a/source/geometry/FloatEuclidTransform.ooc
+++ b/source/geometry/FloatEuclidTransform.ooc
@@ -15,7 +15,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use ooc-collections
-import math
 use ooc-math
 import FloatVector3D
 import FloatRotation3D

--- a/source/geometry/FloatEuclidTransformVectorList.ooc
+++ b/source/geometry/FloatEuclidTransformVectorList.ooc
@@ -16,7 +16,6 @@
 */
 
 use ooc-collections
-import math
 use ooc-math
 import FloatEuclidTransform
 import FloatRotation3D

--- a/source/geometry/FloatPoint2D.ooc
+++ b/source/geometry/FloatPoint2D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 use ooc-math
 import FloatVector2D
 import IntPoint2D

--- a/source/geometry/FloatPoint2DVectorList.ooc
+++ b/source/geometry/FloatPoint2DVectorList.ooc
@@ -16,7 +16,6 @@
 */
 
 use ooc-collections
-import math
 use ooc-math
 import structs/Vector
 import FloatPoint2D

--- a/source/geometry/FloatPoint3D.ooc
+++ b/source/geometry/FloatPoint3D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 use ooc-math
 import FloatPoint2D
 import IntPoint3D

--- a/source/geometry/FloatRotation3D.ooc
+++ b/source/geometry/FloatRotation3D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 use ooc-math
 import Quaternion
 

--- a/source/geometry/FloatShell2D.ooc
+++ b/source/geometry/FloatShell2D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 use ooc-math
 import FloatPoint2D
 import FloatVector2D

--- a/source/geometry/FloatTransform2D.ooc
+++ b/source/geometry/FloatTransform2D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 use ooc-math
 import FloatVector2D
 import FloatPoint2D

--- a/source/geometry/FloatTransform3D.ooc
+++ b/source/geometry/FloatTransform3D.ooc
@@ -15,7 +15,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use ooc-collections
-import math
 use ooc-math
 import FloatVector2D
 import FloatVector3D

--- a/source/geometry/FloatVector2D.ooc
+++ b/source/geometry/FloatVector2D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 use ooc-math
 import FloatPoint2D
 import IntVector2D

--- a/source/geometry/FloatVector3D.ooc
+++ b/source/geometry/FloatVector3D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 use ooc-math
 import FloatPoint3D
 import IntPoint3D

--- a/source/geometry/IntBox2D.ooc
+++ b/source/geometry/IntBox2D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 import IntPoint2D
 import IntVector2D
 import FloatPoint2D

--- a/source/geometry/IntPoint2D.ooc
+++ b/source/geometry/IntPoint2D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 import IntVector2D
 import FloatPoint2D
 use ooc-base

--- a/source/geometry/IntPoint3D.ooc
+++ b/source/geometry/IntPoint3D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 import IntVector3D
 import IntPoint2D
 import FloatPoint3D

--- a/source/geometry/IntShell2D.ooc
+++ b/source/geometry/IntShell2D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 import IntPoint2D
 import IntVector2D
 import IntBox2D

--- a/source/geometry/IntTransform2D.ooc
+++ b/source/geometry/IntTransform2D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 import IntVector2D
 import IntPoint2D
 import FloatTransform2D

--- a/source/geometry/IntVector2D.ooc
+++ b/source/geometry/IntVector2D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 import IntPoint2D
 import FloatVector2D
 use ooc-base

--- a/source/geometry/IntVector3D.ooc
+++ b/source/geometry/IntVector3D.ooc
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 import IntPoint3D
 import FloatVector3D
 use ooc-base

--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -18,7 +18,6 @@ use ooc-collections
 use ooc-math
 import FloatPoint3D
 import FloatTransform3D
-import math
 
 Quaternion: cover {
 	real: Float

--- a/source/math/BoolVectorList.ooc
+++ b/source/math/BoolVectorList.ooc
@@ -15,7 +15,6 @@
 * along with this software. If not, see <http://www.gnu.org/licenses/>.
 */
 use ooc-collections
-import math
 import FloatVectorList
 
 BoolVectorList: class extends VectorList<Bool> {

--- a/source/math/FloatComplex.ooc
+++ b/source/math/FloatComplex.ooc
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 use ooc-base
 
 FloatComplex: cover {

--- a/source/math/FloatComplexVectorList.ooc
+++ b/source/math/FloatComplexVectorList.ooc
@@ -14,10 +14,10 @@
 * You should have received a copy of the GNU Lesser General Public License
 * along with this software. If not, see <http://www.gnu.org/licenses/>.
 */
+
 import FloatComplex
 use ooc-collections
 import FloatVectorList
-import math
 
 FloatComplexVectorList: class extends VectorList<FloatComplex> {
 	init: func ~default {

--- a/source/math/FloatMatrix.ooc
+++ b/source/math/FloatMatrix.ooc
@@ -15,7 +15,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use ooc-base
-import math
 
 FloatMatrix: cover {
 	// x = column

--- a/source/math/FloatRandomGenerator.ooc
+++ b/source/math/FloatRandomGenerator.ooc
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
-import math
+
 import os/Time
 
 FloatRandomGenerator: abstract class {

--- a/source/math/FloatVectorList.ooc
+++ b/source/math/FloatVectorList.ooc
@@ -17,7 +17,6 @@
 use ooc-collections
 use ooc-base
 import structs/Vector
-import math
 import FloatComplex
 import FloatComplexVectorList
 import FloatMatrix

--- a/source/math/IntRandomGenerator.ooc
+++ b/source/math/IntRandomGenerator.ooc
@@ -15,7 +15,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use ooc-math
-import math
 import os/Time
 
 IntRandomGenerator: abstract class {

--- a/source/math/IntVectorList.ooc
+++ b/source/math/IntVectorList.ooc
@@ -15,7 +15,6 @@
 * along with this software. If not, see <http://www.gnu.org/licenses/>.
 */
 use ooc-collections
-import math
 import FloatVectorList
 
 IntVectorList: class extends VectorList<Int> {

--- a/source/plot/Axis.ooc
+++ b/source/plot/Axis.ooc
@@ -1,6 +1,5 @@
 use ooc-geometry
 import svg/Shapes
-import math
 
 Orientation: enum {
 	Horizontal

--- a/source/plot/SvgPlot.ooc
+++ b/source/plot/SvgPlot.ooc
@@ -3,7 +3,6 @@ use ooc-geometry
 use ooc-draw
 import Axis
 import PlotData2D
-import math
 import svg/Shapes
 
 SvgPlot: class {

--- a/source/plot/SvgWriter2D.ooc
+++ b/source/plot/SvgWriter2D.ooc
@@ -8,7 +8,6 @@ import io/FileWriter
 import SvgPlot
 import LinePlotData2D
 import svg/Shapes
-import math
 
 SvgWriter2D: class {
 	file: File { get set }

--- a/source/sdk/OwnedBuffer.ooc
+++ b/source/sdk/OwnedBuffer.ooc
@@ -15,7 +15,6 @@
 * along with this software. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import math
 import Owner
 
 OwnedBuffer: cover {

--- a/source/sdk/Text.ooc
+++ b/source/sdk/Text.ooc
@@ -15,8 +15,6 @@
 * along with this software. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import math
-
 Text: cover {
 	_buffer: TextBuffer
 	count: Int { get {

--- a/source/sdk/structs/VectorList.ooc
+++ b/source/sdk/structs/VectorList.ooc
@@ -14,8 +14,8 @@
 * You should have received a copy of the GNU Lesser General Public License
 * along with this software. If not, see <http://www.gnu.org/licenses/>.
 */
+
 import structs/Vector
-import math
 
 VectorList: class <T> {
 	_vector: Vector<T>

--- a/source/unit/Constraints.ooc
+++ b/source/unit/Constraints.ooc
@@ -16,7 +16,6 @@
  */
 
 use ooc-base
-import math
 
 ComparisonType: enum {
 	Unspecified

--- a/test/base/TimerTest.ooc
+++ b/test/base/TimerTest.ooc
@@ -17,12 +17,11 @@
 
 use ooc-base
 use ooc-unit
-import math
 
 TimerTest: class extends Fixture {
 	timer := Timer new()
 	clockTimer := ClockTimer new()
-	
+
 	init: func {
 		super("Timer")
 		this add("basic use of Timer", func {
@@ -36,14 +35,14 @@ TimerTest: class extends Fixture {
 			expect(slow > fast, is true)
 		})
 	}
-	
+
 	timerTestFunction: func (loopLength: Int) -> Double {
 		sum := 0
 		this timer start()
 		for (i in 0 .. loopLength) { sum = (sum + i) % 10 }
 		this timer stop()
 	}
-	
+
 	clockTimerTestFunction: func (loopLength: Int) -> Double {
 		sum := 0
 		this clockTimer start()

--- a/test/collections/RecycleBinTest.ooc
+++ b/test/collections/RecycleBinTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-base
 use ooc-collections
-import math
 
 MyClass: class {
 	content: Int

--- a/test/collections/VectorQueueTest.ooc
+++ b/test/collections/VectorQueueTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-base
 use ooc-collections
-import math
 
 MyCover: cover {
 	content: Int

--- a/test/concurrent/SynchronizedQueueTest.ooc
+++ b/test/concurrent/SynchronizedQueueTest.ooc
@@ -1,7 +1,6 @@
 use ooc-base
 use ooc-concurrent
 use ooc-unit
-import math
 import threading/Thread
 
 SynchronizedQueueTest: class extends Fixture {

--- a/test/draw/ColorConvertTest.ooc
+++ b/test/draw/ColorConvertTest.ooc
@@ -1,6 +1,5 @@
 use ooc-unit
 use ooc-draw
-import math
 import lang/IO
 
 ColorConvertTest: class extends Fixture {

--- a/test/draw/ImageFileTest.ooc
+++ b/test/draw/ImageFileTest.ooc
@@ -2,7 +2,6 @@ use ooc-unit
 use ooc-draw
 use ooc-base
 use ooc-geometry
-import math
 import lang/IO
 import io/File
 import StbImage

--- a/test/draw/RasterYuv420PlanarTest.ooc
+++ b/test/draw/RasterYuv420PlanarTest.ooc
@@ -1,6 +1,5 @@
 use ooc-unit
 use ooc-draw
-import math
 
 RasterYuv420PlanarTest: class extends Fixture {
 	inputPath := "test/draw/input/Flower.png"

--- a/test/draw/RasterYuv420SemiplanarTest.ooc
+++ b/test/draw/RasterYuv420SemiplanarTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-draw
 use ooc-geometry
-import math
 
 RasterYuv420SemiplanarTest: class extends Fixture {
 	_inputPath := "test/draw/input/Flower.png"

--- a/test/draw/RasterYuv422SemipackedTest.ooc
+++ b/test/draw/RasterYuv422SemipackedTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-draw
 use ooc-geometry
-import math
 
 RasterYuv422SemipackedTest: class extends Fixture {
 	_inputPath := "test/draw/input/Flower.png"

--- a/test/draw/gpu/GpuImageReflectionTest.ooc
+++ b/test/draw/gpu/GpuImageReflectionTest.ooc
@@ -4,7 +4,6 @@ use ooc-draw-gpu
 use ooc-draw
 use ooc-opengl
 use ooc-unit
-import math
 import lang/IO
 import os/Time
 

--- a/test/draw/gpu/GpuImageRotationTest.ooc
+++ b/test/draw/gpu/GpuImageRotationTest.ooc
@@ -4,7 +4,6 @@ use ooc-draw-gpu
 use ooc-draw
 use ooc-opengl
 use ooc-unit
-import math
 import lang/IO
 import os/Time
 

--- a/test/draw/gpu/GpuImageTranslationTest.ooc
+++ b/test/draw/gpu/GpuImageTranslationTest.ooc
@@ -4,7 +4,6 @@ use ooc-draw-gpu
 use ooc-draw
 use ooc-opengl
 use ooc-unit
-import math
 import lang/IO
 import os/Time
 

--- a/test/draw/gpu/GpuSurfaceTest.ooc
+++ b/test/draw/gpu/GpuSurfaceTest.ooc
@@ -5,7 +5,6 @@ use ooc-draw-gpu
 use ooc-draw
 use ooc-opengl
 use ooc-unit
-import math
 import lang/IO
 import os/Time
 

--- a/test/geometry/FloatBox2DTest.ooc
+++ b/test/geometry/FloatBox2DTest.ooc
@@ -2,7 +2,6 @@ use ooc-unit
 use ooc-geometry
 use ooc-collections
 use ooc-base
-import math
 import lang/IO
 
 FloatBox2DTest: class extends Fixture {
@@ -15,8 +14,6 @@ FloatBox2DTest: class extends Fixture {
 		super("FloatBox2D")
 		this add("equality", func {
 			box := FloatBox2D new()
-//			expect(this vector0, is equal to(this vector0))
-//			expect(this vector0 equals(this vector0 as Object), is true)
 			expect(this box0 == this box0, is true)
 			expect(this box0 != this box1, is true)
 			expect(this box0 == box, is false)

--- a/test/geometry/FloatConvexHull2DTest.ooc
+++ b/test/geometry/FloatConvexHull2DTest.ooc
@@ -18,7 +18,6 @@
 use ooc-collections
 use ooc-geometry
 use ooc-unit
-import math
 
 FloatConvexHull2DTest: class extends Fixture {
 	init: func {

--- a/test/geometry/FloatEuclidTransformVectorListTest.ooc
+++ b/test/geometry/FloatEuclidTransformVectorListTest.ooc
@@ -16,7 +16,6 @@
  */
 use ooc-geometry
 use ooc-unit
-import math
 
 FloatEuclidTransformVectorListTest: class extends Fixture {
 	init: func {

--- a/test/geometry/FloatPoint2DTest.ooc
+++ b/test/geometry/FloatPoint2DTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-base
 use ooc-geometry
-import math
 import lang/IO
 
 FloatPoint2DTest: class extends Fixture {
@@ -14,8 +13,6 @@ FloatPoint2DTest: class extends Fixture {
 		super("FloatPoint2D")
 		this add("equality", func {
 			point := FloatPoint2D new()
-//			expect(this point0, is equal to(this point0))
-//			expect(this point0 equals(this point0 as Object), is true)
 			expect(this point0 == this point0, is true)
 			expect(this point0 != this point1, is true)
 			expect(this point0 == point, is false)

--- a/test/geometry/FloatPoint2DVectorListTest.ooc
+++ b/test/geometry/FloatPoint2DVectorListTest.ooc
@@ -17,7 +17,6 @@
 
 use ooc-geometry
 use ooc-unit
-import math
 
 FloatPoint2DVectorListTest: class extends Fixture {
 	init: func {

--- a/test/geometry/FloatPoint3DTest.ooc
+++ b/test/geometry/FloatPoint3DTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-base
 use ooc-geometry
-import math
 import lang/IO
 
 FloatPoint3DTest: class extends Fixture {

--- a/test/geometry/FloatRotation3DTest.ooc
+++ b/test/geometry/FloatRotation3DTest.ooc
@@ -17,7 +17,6 @@
 
 use ooc-geometry
 use ooc-unit
-import math
 
 FloatRotation3DTest: class extends Fixture {
 	quaternion0 := Quaternion new(33.0f, 10.0f, -12.0f, 54.5f)

--- a/test/geometry/FloatShell2DTest.ooc
+++ b/test/geometry/FloatShell2DTest.ooc
@@ -19,7 +19,6 @@ use ooc-base
 use ooc-math
 use ooc-geometry
 use ooc-unit
-import math
 
 FloatShell2DTest: class extends Fixture {
 	init: func {

--- a/test/geometry/FloatSize2DTest.ooc
+++ b/test/geometry/FloatSize2DTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-base
 use ooc-geometry
-import math
 import lang/IO
 
 FloatVector2DTest: class extends Fixture {

--- a/test/geometry/FloatSize3DTest.ooc
+++ b/test/geometry/FloatSize3DTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-base
 use ooc-geometry
-import math
 import lang/IO
 
 FloatVector3DTest: class extends Fixture {

--- a/test/geometry/FloatTransform2DTest.ooc
+++ b/test/geometry/FloatTransform2DTest.ooc
@@ -1,6 +1,5 @@
 use ooc-unit
 use ooc-geometry
-import math
 import lang/IO
 
 FloatTransform2DTest: class extends Fixture {

--- a/test/geometry/FloatTransform3DTest.ooc
+++ b/test/geometry/FloatTransform3DTest.ooc
@@ -1,6 +1,5 @@
 use ooc-unit
 use ooc-geometry
-import math
 import lang/IO
 
 FloatTransform3DTest: class extends Fixture {

--- a/test/geometry/IntBox2DTest.ooc
+++ b/test/geometry/IntBox2DTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-geometry
 use ooc-base
-import math
 import lang/IO
 
 IntBox2DTest: class extends Fixture {
@@ -12,8 +11,6 @@ IntBox2DTest: class extends Fixture {
 		super("IntBox2D")
 		this add("equality", func {
 			box := IntBox2D new()
-//			expect(this vector0, is equal to(this vector0))
-//			expect(this vector0 equals(this vector0 as Object), is true)
 			expect(this box0 == this box0, is true)
 			expect(this box0 != this box1, is true)
 			expect(this box0 == box, is false)

--- a/test/geometry/IntPoint2DTest.ooc
+++ b/test/geometry/IntPoint2DTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-base
 use ooc-geometry
-import math
 import lang/IO
 
 IntPoint2DTest: class extends Fixture {

--- a/test/geometry/IntPoint3DTest.ooc
+++ b/test/geometry/IntPoint3DTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-base
 use ooc-geometry
-import math
 import lang/IO
 
 IntPoint3DTest: class extends Fixture {

--- a/test/geometry/IntShell2DTest.ooc
+++ b/test/geometry/IntShell2DTest.ooc
@@ -19,7 +19,6 @@ use ooc-base
 use ooc-math
 use ooc-geometry
 use ooc-unit
-import math
 
 IntShell2DTest: class extends Fixture {
 	init: func {

--- a/test/geometry/IntTransform2DTest.ooc
+++ b/test/geometry/IntTransform2DTest.ooc
@@ -1,6 +1,5 @@
 use ooc-unit
 use ooc-geometry
-import math
 import lang/IO
 
 IntTransform2DTest: class extends Fixture {

--- a/test/geometry/IntVector2DTest.ooc
+++ b/test/geometry/IntVector2DTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-base
 use ooc-geometry
-import math
 import lang/IO
 
 IntVector2DTest: class extends Fixture {

--- a/test/geometry/IntVector3DTest.ooc
+++ b/test/geometry/IntVector3DTest.ooc
@@ -1,7 +1,6 @@
 use ooc-unit
 use ooc-base
 use ooc-geometry
-import math
 import lang/IO
 
 IntVector3DTest: class extends Fixture {

--- a/test/geometry/QuaternionTest.ooc
+++ b/test/geometry/QuaternionTest.ooc
@@ -20,7 +20,6 @@ use ooc-collections
 use ooc-unit
 use ooc-math
 use ooc-geometry
-import math
 import lang/IO
 
 QuaternionTest: class extends Fixture {

--- a/test/math/AlignTest.ooc
+++ b/test/math/AlignTest.ooc
@@ -1,6 +1,5 @@
 use ooc-math
 use ooc-unit
-import math
 
 AlignTest: class extends Fixture {
 	init: func {

--- a/test/math/BoolVectorListTest.ooc
+++ b/test/math/BoolVectorListTest.ooc
@@ -18,7 +18,6 @@
 use ooc-base
 use ooc-math
 use ooc-unit
-import math
 
 BoolVectorListTest: class extends Fixture {
 	init: func {

--- a/test/math/FloatComplexTest.ooc
+++ b/test/math/FloatComplexTest.ooc
@@ -18,7 +18,6 @@ use ooc-unit
 use ooc-base
 use ooc-math
 use ooc-collections
-import math
 import FloatComplex
 import lang/IO
 import structs/Vector

--- a/test/math/FloatComplexVectorListTest.ooc
+++ b/test/math/FloatComplexVectorListTest.ooc
@@ -17,7 +17,6 @@
 use ooc-unit
 use ooc-math
 use ooc-collections
-import math
 import FloatComplex
 import FloatComplexVectorList
 import lang/IO

--- a/test/math/FloatExtensionTest.ooc
+++ b/test/math/FloatExtensionTest.ooc
@@ -1,6 +1,5 @@
 use ooc-unit
 use ooc-math
-import math
 import lang/IO
 
 FloatExtensionTest: class extends Fixture {

--- a/test/math/FloatMatrixTest.ooc
+++ b/test/math/FloatMatrixTest.ooc
@@ -1,7 +1,6 @@
 use ooc-base
 use ooc-unit
 use ooc-math
-import math
 import lang/IO
 
 FloatMatrixTest: class extends Fixture {

--- a/test/math/FloatRandomGeneratorTest.ooc
+++ b/test/math/FloatRandomGeneratorTest.ooc
@@ -1,6 +1,5 @@
 use ooc-unit
 use ooc-math
-import math
 
 FloatRandomGeneratorTest: class extends Fixture {
 	init: func {

--- a/test/math/FloatVectorListTest.ooc
+++ b/test/math/FloatVectorListTest.ooc
@@ -17,7 +17,6 @@
 use ooc-unit
 use ooc-math
 use ooc-collections
-import math
 import lang/IO
 
 FloatVectorListTest: class extends Fixture {

--- a/test/math/IntRandomGeneratorTest.ooc
+++ b/test/math/IntRandomGeneratorTest.ooc
@@ -1,6 +1,5 @@
 use ooc-unit
 use ooc-math
-import math
 
 IntRandomGeneratorTest: class extends Fixture {
 	init: func {

--- a/test/math/IntVectorListTest.ooc
+++ b/test/math/IntVectorListTest.ooc
@@ -17,7 +17,6 @@
 use ooc-unit
 use ooc-math
 use ooc-collections
-import math
 import lang/IO
 
 IntVectorListTest: class extends Fixture {

--- a/test/math/RangeTest.ooc
+++ b/test/math/RangeTest.ooc
@@ -1,6 +1,5 @@
 use ooc-unit
 use ooc-math
-import math
 import lang/IO
 
 RangeTest: class extends Fixture {

--- a/test/plot/SvgPlotTest.ooc
+++ b/test/plot/SvgPlotTest.ooc
@@ -4,7 +4,6 @@ use ooc-math
 use ooc-geometry
 use ooc-collections
 use ooc-draw
-import math
 import io/File
 
 logVector := VectorList<FloatPoint2D> new()

--- a/test/sdk/MathTest.ooc
+++ b/test/sdk/MathTest.ooc
@@ -1,5 +1,4 @@
 use ooc-unit
-import math
 
 MathTest: class extends Fixture {
 	init: func {

--- a/test/sdk/OwnedBufferTest.ooc
+++ b/test/sdk/OwnedBufferTest.ooc
@@ -1,7 +1,6 @@
 use ooc-base
 use ooc-unit
 use ooc-geometry
-import math
 
 OwnedBufferTest: class extends Fixture {
 	init: func {

--- a/test/sdk/OwnedClosureTest.ooc
+++ b/test/sdk/OwnedClosureTest.ooc
@@ -1,6 +1,5 @@
 use ooc-base
 use ooc-unit
-import math
 
 MyClass: class {
 	content: Int { get set }

--- a/test/sdk/TextLiteralTest.ooc
+++ b/test/sdk/TextLiteralTest.ooc
@@ -1,7 +1,6 @@
 use ooc-base
 use ooc-unit
 use ooc-geometry
-import math
 
 TextLiteralTest: class extends Fixture {
 	init: func {

--- a/test/sdk/TextTest.ooc
+++ b/test/sdk/TextTest.ooc
@@ -1,7 +1,6 @@
 use ooc-base
 use ooc-unit
 use ooc-geometry
-import math
 
 TextTest: class extends Fixture {
 	init: func {


### PR DESCRIPTION
Added `Import: math` to `sdk.use` according to the discussion in #541 - now we no longer need `import math` anywhere.

@sebastianbaginski @simonmika ?