### PR TITLE
Fixed memory leaks in SDK tests

### DIFF
--- a/test/sdk/StackTest.ooc
+++ b/test/sdk/StackTest.ooc
@@ -17,6 +17,7 @@ StackTest: class extends Fixture {
 			expect(stack isEmpty, is false)
 			stack clear()
 			expect(stack isEmpty, is true)
+			stack free()
 		})
 		this add("pop, top, peek", func {
 			stack := Stack<Int> new()
@@ -30,6 +31,7 @@ StackTest: class extends Fixture {
 			expect(first - second, is equal to(1))
 			expect(first, is equal to(4999))
 			expect(second, is equal to(4998))
+			stack free()
 		})
 		this add("clearing", func {
 			stack := Stack<Int> new()
@@ -43,8 +45,9 @@ StackTest: class extends Fixture {
 			}
 			expect(stack pop(), is equal to(1))
 			expect(stack isEmpty, is true)
+			stack free()
 		})
 	}
 }
-	
+
 StackTest new() run() . free()

--- a/test/sdk/TextLiteralTest.ooc
+++ b/test/sdk/TextLiteralTest.ooc
@@ -7,12 +7,16 @@ TextLiteralTest: class extends Fixture {
 		super("TextLiteral")
 		this add("constructors", func {
 			t := Text new(c"test string", 5)
-			expect(t toString() == "test ")
+			string := t toString()
+			expect(string == "test ")
+			string free()
 			t =t"string"
 			t2 := t"str"
 			expect(t count == 6)
-			expect(t toString() == "string")
-			expect(t isEmpty == false)
+			string = t toString()
+			expect(string == "string")
+			string free()
+			expect(t isEmpty, is false)
 			t = t give()
 			t free()
 			expect(t count == 0)


### PR DESCRIPTION
Pretty much only errors related to `File` remain.

@sebastianbaginski ?