### PR TITLE
Reduced memory leaks in io tests

### DIFF
--- a/source/io/CsvWriter.ooc
+++ b/source/io/CsvWriter.ooc
@@ -24,7 +24,9 @@ CsvWriter: class {
 				}
 			if (i < row count - 1)
 				value append(CsvReader delimiter)
-			this _fileWriter file write(value toString())
+			string := value toString()
+			this _fileWriter file write(string)
+			string free()
 			value free()
 		}
 		this _fileWriter write("\r\n")

--- a/test/io/CsvReaderTest.ooc
+++ b/test/io/CsvReaderTest.ooc
@@ -11,8 +11,12 @@ CsvReaderTest: class extends Fixture {
 			reader := CsvReader open(filename)
 			rowCounter := 0
 			for (row in reader) {
-				for (i in 0 .. row count)
-					expect(row[i] toString(), is equal to(((i + 1) + rowCounter * 3) toString()))
+				for (i in 0 .. row count) {
+					rowString := row[i] toString()
+					correctAnswer := ((i + 1) + rowCounter * 3) toString()
+					expect(rowString, is equal to(correctAnswer))
+					rowString free(); correctAnswer free()
+				}
 				row free()
 				++rowCounter
 			}
@@ -45,11 +49,8 @@ CsvReaderTest: class extends Fixture {
 			reader free()
 		})
 	}
-	toFloat: static func (value: Text) -> Float {
-		value toFloat()
-	}
 	toFloats: static func (row: VectorList<Text>) -> VectorList<Float> {
-		row map(|value| This toFloat)
+		row map(|value| value toFloat())
 	}
 }
 

--- a/test/io/CsvWriterTest.ooc
+++ b/test/io/CsvWriterTest.ooc
@@ -24,13 +24,18 @@ CsvWriterTest: class extends Fixture {
 			reader = CsvReader open(outputFilename)
 			rowCounter := 0
 			for (row in reader) {
-				for (i in 0 .. row count)
-					expect(row[i] toString(), is equal to(((i + 1) + rowCounter * 3) toString()))
+				for (i in 0 .. row count) {
+					rowString := row[i] toString()
+					correctAnswer := ((i + 1) + rowCounter * 3) toString()
+					expect(rowString, is equal to(correctAnswer))
+					rowString free(); correctAnswer free()
+				}
 				row free()
 				++rowCounter
 			}
 			reader free()
 			outputFilename free()
+			csvRecords free()
 		})
 	}
 	_createOutputDirectory: func {


### PR DESCRIPTION
Removed 75%. Only one big remains, and I think the problem lies deeper:

```
11,736 (216 direct, 11,520 indirect) bytes in 9 blocks are definitely lost in loss record 629 of 629
    at 0x4C2CC70: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x451229: lang_Memory__gc_malloc (Memory.ooc:8)
    by 0x4544E1: lang_types__Class_alloc__class (types.ooc:49)
    by 0x4538CC: lang_String__String_new_withBuffer (String.ooc:21)
    by 0x457795: TextBuffer__TextBuffer_toString (TextBuffer.ooc:77)
    by 0x45909A: Text__Text_toString (Text.ooc:208)
    by 0x443DAC: TextBuilder__TextBuilder_toString (TextBuilder.ooc:70)
    by 0x433B74: CsvWriter__CsvWriter_write (CsvWriter.ooc:27)
    by 0x4326E7: test_io_CsvWriterTest____test_io_CsvWriterTest_test_io_CsvWriterTest_closure11 (CsvWriterTest.ooc:21)
    by 0x437846: Fixture__Test_run (Fixture.ooc:201)
    by 0x436956: Fixture__Fixture_run (Fixture.ooc:66)
    by 0x4325BB: test_io_CsvWriterTest_load (CsvWriterTest.ooc:48)
    by 0x432181: ___test_Tests_load (Tests.c:50)
    by 0x4321B0: main (Tests.c:58)
```

Or maybe I just don't see it because it's a late Friday afternoon. If you have any idea to fix it, let me know. @sebastianbaginski 