### PR TITLE
Changed multiple static functions in math.ooc to nonstatic

### DIFF
--- a/source/draw/gpu/opengl/GraphicBufferYuv420Semiplanar.ooc
+++ b/source/draw/gpu/opengl/GraphicBufferYuv420Semiplanar.ooc
@@ -50,7 +50,7 @@ GraphicBufferYuv420Semiplanar: class extends RasterYuv420Semiplanar {
 			this _rgba = This _search(this _buffer)
 		if (this _rgba == null) {
 			padding := this _uvOffset - this _stride * this _size y
-			extraRows := Int align(padding, this _stride) / this _stride
+			extraRows := padding align(this _stride) / this _stride
 			height := this _size y + this _size y / 2 + extraRows
 			width := this _stride / 4
 			rgbaBuffer := this buffer shallowCopy(IntVector2D new(width, height), width, GraphicBufferFormat Rgba8888, GraphicBufferUsage Texture | GraphicBufferUsage RenderTarget)

--- a/source/geometry/FloatPoint2D.ooc
+++ b/source/geometry/FloatPoint2D.ooc
@@ -77,7 +77,7 @@ FloatPoint2D: cover {
 		result
 	}
 	linearInterpolation: static func (a, b: This, ratio: Float) -> This {
-		This new(Float linearInterpolation(a x, b x, ratio), Float linearInterpolation(a y, b y, ratio))
+		This new(ratio linearInterpolation(a x, b x), ratio linearInterpolation(a y, b y))
 	}
 }
 operator * (left: Float, right: FloatPoint2D) -> FloatPoint2D { FloatPoint2D new(left * right x, left * right y) }

--- a/source/geometry/FloatPoint2DVectorList.ooc
+++ b/source/geometry/FloatPoint2DVectorList.ooc
@@ -112,7 +112,7 @@ FloatPoint2DVectorList: class extends VectorList<FloatPoint2D> {
 						previousIndex = j
 					} else break
 				weight := (point x - leftPoint x) absolute / (rightPoint x - leftPoint x) absolute
-				point y = Float linearInterpolation(leftPoint y, rightPoint y, weight)
+				point y = weight linearInterpolation(leftPoint y, rightPoint y)
 			}
 			result add(point)
 		}

--- a/source/geometry/FloatPoint3D.ooc
+++ b/source/geometry/FloatPoint3D.ooc
@@ -82,7 +82,7 @@ FloatPoint3D: cover {
 		result
 	}
 	linearInterpolation: static func (a, b: This, ratio: Float) -> This {
-		This new(Float linearInterpolation(a x, b x, ratio), Float linearInterpolation(a y, b y, ratio), Float linearInterpolation(a z, b z, ratio))
+		This new(ratio linearInterpolation(a x, b x), ratio linearInterpolation(a y, b y), ratio linearInterpolation(a z, b z))
 	}
 	kean_math_floatPoint3D_new: unmangled static func (x, y, z: Float) -> This { This new(x, y, z) }
 }

--- a/source/geometry/FloatVector2D.ooc
+++ b/source/geometry/FloatVector2D.ooc
@@ -82,7 +82,7 @@ FloatVector2D: cover {
 		result
 	}
 	linearInterpolation: static func (a, b: This, ratio: Float) -> This {
-		This new(Float linearInterpolation(a x, b x, ratio), Float linearInterpolation(a y, b y, ratio))
+		This new(ratio linearInterpolation(a x, b x), ratio linearInterpolation(a y, b y))
 	}
 }
 operator * (left: Float, right: FloatVector2D) -> FloatVector2D { FloatVector2D new(left * right x, left * right y) }

--- a/source/geometry/FloatVector3D.ooc
+++ b/source/geometry/FloatVector3D.ooc
@@ -85,7 +85,7 @@ FloatVector3D: cover {
 		result
 	}
 	linearInterpolation: static func (a, b: This, ratio: Float) -> This {
-		This new(Float linearInterpolation(a x, b x, ratio), Float linearInterpolation(a y, b y, ratio), Float linearInterpolation(a z, b z, ratio))
+		This new(ratio linearInterpolation(a x, b x), ratio linearInterpolation(a y, b y), ratio linearInterpolation(a z, b z))
 	}
 	kean_math_floatVector3D_new: unmangled static func (x, y, z: Float) -> This { This new(x, y, z) }
 }

--- a/source/math/FloatVectorList.ooc
+++ b/source/math/FloatVectorList.ooc
@@ -303,7 +303,7 @@ FloatVectorList: class extends VectorList<Float> {
 			for (index1 in 0 .. this count - 1) {
 				result add(thisPointer[index1])
 				for (index2 in 1 .. numberOfPoints + 1)
-					result add(Float linearInterpolation(thisPointer[index1], thisPointer[index1 + 1], index2 as Float / (numberOfPoints + 1) as Float))
+					result add((index2 as Float / (numberOfPoints + 1) as Float) linearInterpolation(thisPointer[index1], thisPointer[index1 + 1]))
 			}
 			result add(thisPointer[this count - 1])
 		} else

--- a/source/sdk/math.ooc
+++ b/source/sdk/math.ooc
@@ -44,49 +44,38 @@ extend Int {
 	isEven ::= this modulo(2) == 0
 	squared ::= this * this
 
-	pow: func (other: This) -> This {
-		(this as Float) pow(other as Float) as Int
-	}
+	pow: func (other: This) -> This { (this as Float) pow(other as Float) as Int }
+	clamp: func (floor, ceiling: This) -> This { this > ceiling ? ceiling : (this < floor ? floor : this) }
 	modulo: func (divisor: This) -> This {
 		result := this
 		if (result < 0)
 			result += (((result abs() as Float) / divisor) ceil() as Int) * divisor
 		result % divisor
 	}
-	clamp: func (floor, ceiling: This) -> This {
-		this > ceiling ? ceiling : (this < floor ? floor : this)
-	}
-	maximum: static func (first, second: This) -> This {
-		first > second ? first : second
-	}
-	minimum: static func (first, second: This) -> This {
-		first < second ? first : second
-	}
-	align: static func (x, align: Int) -> This {
-		result := x
-		if (align > 0) {
-			remainder := x % align
-			if (remainder > 0)
-				result = x + align - remainder
-		}
-		result
-	}
-	alignPowerOfTwo: static func (x, align: Int) -> This { align > 0 ? (x + align - 1) & ~(align - 1) : x }
-	toPowerOfTwo: static func (x: Int) -> This {
-		result := x == 0 ? 0 : 1
-		while (result < x)
-			result *= 2
-		result
-	}
-	digits: static func (x: Int) -> This {
-		result := x < 0 ? 2 : 1
-		value := This abs(x)
+	digits: func -> This {
+		result := this < 0 ? 2 : 1
+		value := this absolute
 		while (value >= 10) {
 			result += 1
 			value /= 10
 		}
 		result
 	}
+	align: func (align: Int) -> This {
+		result := this
+		if (align > 0) {
+			remainder := this % align
+			if (remainder > 0)
+				result = this + align - remainder
+		}
+		result
+	}
+	alignPowerOfTwo: func (align: Int) -> This {
+		align > 0 ? (this + align - 1) & ~(align - 1) : this
+	}
+
+	maximum: static func (x, y: This) -> This { x > y ? x : y }
+	minimum: static func (x, y: This) -> This { x < y ? x : y }
 }
 
 extend Double {
@@ -130,22 +119,23 @@ extend Double {
 	floor: extern (floor) func -> This
 	truncate: extern (trunc) func -> This
 
-	toRadians: func -> This { This pi / 180.0 * this }
-	toDegrees: func -> This { 180.0 / This pi * this }
-	clamp: func (floor, ceiling: This) -> This {
-		this > ceiling ? ceiling : (this < floor ? floor : this)
-	}
 	modulo: func (divisor: This) -> This {
 		result := this
 		if (result < 0)
 			result += ((result abs()) / divisor) ceil() * divisor
 		result mod(divisor)
 	}
+	toRadians: func -> This { This pi / 180.0 * this }
+	toDegrees: func -> This { 180.0 / This pi * this }
+	clamp: func (floor, ceiling: This) -> This { this > ceiling ? ceiling : (this < floor ? floor : this) }
 	equals: func (other: This, tolerance := This defaultTolerance) -> Bool { (this - other) abs() < tolerance }
 	lessThan: func (other: This, tolerance := This defaultTolerance) -> Bool { this < other && !this equals(other) }
 	greaterThan: func (other: This, tolerance := This defaultTolerance) -> Bool { this > other && !this equals(other) }
 	lessOrEqual: func (other: This, tolerance := This defaultTolerance) -> Bool { !this greaterThan(other) }
 	greaterOrEqual: func (other: This, tolerance := This defaultTolerance) -> Bool { !this lessThan(other) }
+
+	maximum: static func (x, y: This) -> This { x > y ? x : y }
+	minimum: static func (x, y: This) -> This { x < y ? x : y }
 }
 
 extend Float {
@@ -192,9 +182,14 @@ extend Float {
 	floor: extern (floorf) func -> This
 	truncate: extern (truncf) func -> This
 
-	clamp: func (floor, ceiling: This) -> This {
-		this > ceiling ? ceiling : (this < floor ? floor : this)
-	}
+	equals: func (other: This, tolerance := This defaultTolerance) -> Bool { (this - other) abs() < tolerance }
+	lessThan: func (other: This, tolerance := This defaultTolerance) -> Bool { this < other && !this equals(other) }
+	greaterThan: func (other: This, tolerance := This defaultTolerance) -> Bool { this > other && !this equals(other) }
+	lessOrEqual: func (other: This, tolerance := This defaultTolerance) -> Bool { !this greaterThan(other) }
+	greaterOrEqual: func (other: This, tolerance := This defaultTolerance) -> Bool { !this lessThan(other) }
+	linearInterpolation: func (a: This, b: This) -> This { (this * (b - a)) + a }
+	inverseLinearInterpolation: func (a: This, b: This) -> This { (this - a) / (b - a) }
+	clamp: func (floor, ceiling: This) -> This { this > ceiling ? ceiling : (this < floor ? floor : this) }
 	toRadians: func -> This { This pi / 180.0f * this }
 	toDegrees: func -> This { 180.0f / This pi * this }
 	modulo: func (divisor: This) -> This {
@@ -203,23 +198,9 @@ extend Float {
 			result += ((result abs()) / divisor) ceil() * divisor
 		result mod(divisor)
 	}
-	equals: func (other: This, tolerance := This defaultTolerance) -> Bool { (this - other) abs() < tolerance }
-	lessThan: func (other: This, tolerance := This defaultTolerance) -> Bool { this < other && !this equals(other) }
-	greaterThan: func (other: This, tolerance := This defaultTolerance) -> Bool { this > other && !this equals(other) }
-	lessOrEqual: func (other: This, tolerance := This defaultTolerance) -> Bool { !this greaterThan(other) }
-	greaterOrEqual: func (other: This, tolerance := This defaultTolerance) -> Bool { !this lessThan(other) }
-	maximum: static func (first, second: This) -> This {
-		first > second ? first : second
-	}
-	minimum: static func (first, second: This) -> This {
-		first < second ? first : second
-	}
-	linearInterpolation: static func (a: This, b: This, ratio: This) -> This {
-		(ratio * (b - a)) + a
-	}
-	inverseLinearInterpolation: static func (a: This, b: This, value: This) -> This {
-		(value - a) / (b - a)
-	}
+
+	maximum: static func (x, y: This) -> This { x > y ? x : y }
+	minimum: static func (x, y: This) -> This { x < y ? x : y }
 	decomposeToCoefficientAndRadix: static func (value: This, valueDigits: Int) -> (This, This) {
 		radix := 1.0f
 		if (value != 0.0f) {

--- a/test/math/AlignTest.ooc
+++ b/test/math/AlignTest.ooc
@@ -5,12 +5,12 @@ AlignTest: class extends Fixture {
 	init: func {
 		super("AlignTest")
 		this add("align to 64", func {
-			result := Int align(720, 64)
+			result := 720 align(64)
 			expect(result, is equal to(768))
 		})
 		this add("align to 1", func {
 			for (i in 0 .. 66)
-				expect(Int align(i, 1), is equal to(i))
+				expect(i align(1), is equal to(i))
 		})
 	}
 }

--- a/test/sdk/MathTest.ooc
+++ b/test/sdk/MathTest.ooc
@@ -45,9 +45,8 @@ MathTest: class extends Fixture {
 
 			expect(5 squared, is equal to((-5) squared))
 
-			expect(Int toPowerOfTwo(7), is equal to(8))
-			expect(Int alignPowerOfTwo(62, 64), is equal to(64))
-			expect(Int alignPowerOfTwo(137, 128), is equal to(256))
+			expect(62 alignPowerOfTwo(64), is equal to(64))
+			expect(137 alignPowerOfTwo(128), is equal to(256))
 		})
 		this add("Float", func {
 			expect(22.3f modulo(5), is equal to(2.3f) within(floatTolerance))
@@ -79,8 +78,8 @@ MathTest: class extends Fixture {
 
 			expect(10.f squared, is equal to(100.f) within(floatTolerance))
 
-			expect(Float linearInterpolation(2.0f, 5.0f, 0.5f), is equal to(3.5f) within(floatTolerance))
-			expect(Float linearInterpolation(-9.0f, 1.0f, 0.1f), is equal to(-8.f) within(floatTolerance))
+			expect(0.5f linearInterpolation(2.0f, 5.0f), is equal to(3.5f) within(floatTolerance))
+			expect(0.1f linearInterpolation(-9.0f, 1.0f), is equal to(-8.f) within(floatTolerance))
 
 			nearZero := (0.1f + 0.1f + 0.1f) - 0.3f
 			expect(nearZero equals(0.0f), is true)


### PR DESCRIPTION
Fixes the last part of #706 

This will need quite a lot of changes, mostly because of `minimum` and `maximum`, so let's all agree on this before we proceed. 

@simonmika says there should be no static methods on the number covers. That means instead of `Int maximum(2,3)` we do `2 maximum(3)`. Instead of `Float linearInterpolation(0, 1, 0.5f)` we do `0.5f linearInterpolation(0, 1)`, and so on. I can see a benefit of that.

Thoughts? @sebastianbaginski @thomasfanell @niklasborwell 