### PR TITLE
Added support for combined single char cli argument flags

### DIFF
--- a/source/cli/ArgumentParser.ooc
+++ b/source/cli/ArgumentParser.ooc
@@ -80,31 +80,39 @@ ArgumentParser: class {
 	}
 	parse: func (input: VectorList<Text>) {
 		parameters := VectorList<Text> new()
+		arguments := VectorList<Text> new()
 		for (i in 0 .. input count) {
 			parameters clear()
+			arguments clear()
 			current := input[i] take()
 			if (current beginsWith(t"--"))
-				current = current slice(2)
-			else if (current beginsWith(t"-"))
+				arguments add(current slice(2))
+			else if (current beginsWith(t"-")) {
 				current = current slice(1)
+				for (j in 0 .. current count)
+					arguments add(current slice(j, 1))
+			}
 			else
 				this _defaultArgument _textAction call(current)
-			if (argument := this _findArgument(current)) {
-				if (argument _parameters > 1) {
-					for (j in 0 .. argument _parameters)
-						parameters add(input[i + j + 1] take())
-					argument _listAction call(parameters)
+			for (k in 0 .. arguments count) {
+				if (argument := this _findArgument(arguments[k])) {
+					if (argument _parameters > 1) {
+						for (j in 0 .. argument _parameters)
+							parameters add(input[i + j + 1] take())
+						argument _listAction call(parameters)
+					}
+					else if (argument _parameters == 1)
+						argument _textAction call(input[i + 1] take())
+					else
+						argument _action call()
+					i += argument _parameters
 				}
-				else if (argument _parameters == 1)
-					argument _textAction call(input[i + 1] take())
-				else
-					argument _action call()
-				i += argument _parameters
 			}
 		}
 		for (i in 0 .. input count)
 			input[i] free(Owner Receiver)
 		parameters free()
+		arguments free()
 	}
 	_findArgument: func (identifier: Text) -> _Argument {
 		result: _Argument

--- a/test/cli/ArgumentParserTest.ooc
+++ b/test/cli/ArgumentParserTest.ooc
@@ -108,6 +108,7 @@ ArgumentParserTest: class extends Fixture {
 			argumentAValue: Text
 			argumentAValue = t""
 			argumentBValue: Text
+			argumentBValue = t""
 			argumentCFirstValue: Text
 			argumentCSecondValue: Text
 			argumentCThirdValue: Text
@@ -119,7 +120,7 @@ ArgumentParserTest: class extends Fixture {
 			parser add(t"argd", 2, Event1<VectorList<Text>> new(func (list: VectorList<Text>) { argumentDFirstValue = list[0]; argumentDSecondValue = list[1] }))
 			parser parse(inputList)
 			expect(argumentAValue == t"")
-			expect(argumentBValue == t"b")
+			expect(argumentBValue == t"")
 			expect(argumentCFirstValue == t"5")
 			expect(argumentCSecondValue == t"-10")
 			expect(argumentCThirdValue == t"15")
@@ -134,6 +135,37 @@ ArgumentParserTest: class extends Fixture {
 			argumentCThirdValue free()
 			argumentDFirstValue free()
 			argumentDSecondValue free()
+		})
+		this add("Compact flags", func {
+			inputList := VectorList<Text> new()
+			inputList add(t"-abc")
+			inputList add(t"default")
+			inputList add(t"--argd")
+			inputList add(t"dVal")
+			parser := ArgumentParser new()
+			argumentAValue: Text
+			argumentBValue: Text
+			argumentCValue: Text
+			argumentDValue: Text
+			defaultArgumentValue: Text
+			parser add(t"arga", 'a', Event new(func { argumentAValue = t"a" }))
+			parser add(t"argb", 'b', Event new(func { argumentBValue = t"b" }))
+			parser add(t"argc", 'c', Event new(func { argumentCValue = t"c" }))
+			parser add(t"argd", 'd', Event1<Text> new(func (parameter: Text) { argumentDValue = parameter }))
+			parser addDefault(Event1<Text> new(func (parameter: Text) { defaultArgumentValue = parameter }))
+			parser parse(inputList)
+			expect(argumentAValue == t"a")
+			expect(argumentBValue == t"b")
+			expect(argumentCValue == t"c")
+			expect(argumentDValue == t"dVal")
+			expect(defaultArgumentValue == t"default")
+			inputList free()
+			parser free()
+			argumentAValue free()
+			argumentBValue free()
+			argumentCValue free()
+			argumentDValue free()
+			defaultArgumentValue free()
 		})
 	}
 }


### PR DESCRIPTION
Before this you could not write `-abc` to set the flags `a`, `b` and `c`.