### PR TITLE
Quaternion cleanup

### DIFF
--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -28,12 +28,6 @@ Quaternion: cover {
 	y ::= this imaginary y
 	z ::= this imaginary z
 
-	// NOTE: The coordinates are represented differently in C# Kean:
-	// x = this w
-	// y = this x
-	// z = this y
-	// w = this z
-
 	isValid ::= this real isNumber && this imaginary isValid
 	isIdentity ::= this real equals(1.f) && this imaginary x equals(0.f) && this imaginary y equals(0.f) && this imaginary z equals(0.f)
 	isZero ::= this real equals(0.f) && this imaginary x equals(0.f) && this imaginary y equals(0.f) && this imaginary z equals(0.f)

--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -219,6 +219,7 @@ Quaternion: cover {
 	createRotationX: static func (angle: Float) -> This { This createRotation(angle, FloatVector3D new(1.0f, 0.0f, 0.0f)) }
 	createRotationY: static func (angle: Float) -> This { This createRotation(angle, FloatVector3D new(0.0f, 1.0f, 0.0f)) }
 	createRotationZ: static func (angle: Float) -> This { This createRotation(angle, FloatVector3D new(0.0f, 0.0f, 1.0f)) }
+	createFromAxisAngle: static func (vector: FloatVector3D) -> This { This createRotation(vector norm, vector normalized) }
 	hamiltonProduct: static func (left, right: This) -> This {
 		(a1, b1, c1, d1) := (left w, left x, left y, left z)
 		(a2, b2, c2, d2) := (right w, right x, right y, right z)
@@ -227,19 +228,6 @@ Quaternion: cover {
 		y := a1 * c2 - b1 * d2 + c1 * a2 + d1 * b2
 		z := a1 * d2 + b1 * c2 - c1 * b2 + d1 * a2
 		This new(w, x, y, z)
-	}
-	relativeFromVelocity: static func (angularVelocity: FloatPoint3D) -> This {
-		result := This identity
-		angle := sqrt(angularVelocity x * angularVelocity x + angularVelocity y * angularVelocity y + angularVelocity z * angularVelocity z)
-		if (angle > 1.0e-8f) {
-			result = This new(
-				cos(angle / 2.0f),
-				angularVelocity x * sin(angle / 2.0f) / angle,
-				angularVelocity y * sin(angle / 2.0f) / angle,
-				angularVelocity z * sin(angle / 2.0f) / angle
-				)
-		}
-		result
 	}
 	weightedMean: static func (quaternions: VectorList<This>, weights: FloatVectorList) -> This {
 		// Implementation of the QUEST algorithm. Original publication:

--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -17,6 +17,7 @@
 use ooc-collections
 use ooc-math
 import FloatPoint3D
+import FloatVector3D
 import FloatTransform3D
 
 Quaternion: cover {
@@ -208,16 +209,16 @@ Quaternion: cover {
 	createFromEulerAngles: static func (rotationX, rotationY, rotationZ: Float) -> This {
 		This createRotationZ(rotationZ) * This createRotationY(rotationY) * This createRotationX(rotationX)
 	}
-	createRotation: static func (angle: Float, direction: FloatPoint3D) -> This {
+	createRotation: static func (angle: Float, direction: FloatVector3D) -> This {
 		halfAngle := angle / 2.0f
 		point3DNorm := direction norm
 		if (point3DNorm != 0.0f)
 			direction /= point3DNorm
-		This new(0.0f, halfAngle * direction) exponential
+		This new(0.0f, (halfAngle * direction) toFloatPoint3D()) exponential
 	}
-	createRotationX: static func (angle: Float) -> This { This createRotation(angle, FloatPoint3D new(1.0f, 0.0f, 0.0f)) }
-	createRotationY: static func (angle: Float) -> This { This createRotation(angle, FloatPoint3D new(0.0f, 1.0f, 0.0f)) }
-	createRotationZ: static func (angle: Float) -> This { This createRotation(angle, FloatPoint3D new(0.0f, 0.0f, 1.0f)) }
+	createRotationX: static func (angle: Float) -> This { This createRotation(angle, FloatVector3D new(1.0f, 0.0f, 0.0f)) }
+	createRotationY: static func (angle: Float) -> This { This createRotation(angle, FloatVector3D new(0.0f, 1.0f, 0.0f)) }
+	createRotationZ: static func (angle: Float) -> This { This createRotation(angle, FloatVector3D new(0.0f, 0.0f, 1.0f)) }
 	hamiltonProduct: static func (left, right: This) -> This {
 		(a1, b1, c1, d1) := (left w, left x, left y, left z)
 		(a2, b2, c2, d2) := (right w, right x, right y, right z)

--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -36,7 +36,7 @@ Quaternion: cover {
 
 	isValid ::= this real isNumber && this imaginary isValid
 	isIdentity ::= this real equals(1.f) && this imaginary x equals(0.f) && this imaginary y equals(0.f) && this imaginary z equals(0.f)
-	isNull ::= this real equals(0.f) && this imaginary x equals(0.f) && this imaginary y equals(0.f) && this imaginary z equals(0.f)
+	isZero ::= this real equals(0.f) && this imaginary x equals(0.f) && this imaginary y equals(0.f) && this imaginary z equals(0.f)
 	norm ::= (this real squared + this imaginary norm squared) sqrt()
 	normalized ::= this / this norm
 	logarithmImaginaryNorm ::= ((this logarithm) imaginary) norm

--- a/test/geometry/FloatRotation3DTest.ooc
+++ b/test/geometry/FloatRotation3DTest.ooc
@@ -75,7 +75,7 @@ FloatRotation3DTest: class extends Fixture {
 			expect(interpolated _quaternion z, is equal to(0.700140f) within(tolerance))
 		})
 		this add("angle", func {
-			direction := FloatPoint3D new(1.0f, 1.0f, 1.0f)
+			direction := FloatVector3D new(1.0f, 1.0f, 1.0f)
 			quaternionA := Quaternion createRotation(20.0f toRadians(), direction)
 			quaternionB := Quaternion createRotation(45.0f toRadians(), direction)
 			rotationA := FloatRotation3D new(quaternionA)

--- a/test/geometry/QuaternionTest.ooc
+++ b/test/geometry/QuaternionTest.ooc
@@ -48,7 +48,7 @@ QuaternionTest: class extends Fixture {
 		})
 		this add("properties", func {
 			expect(this quaternion7 isIdentity)
-			expect((this quaternion7 - this quaternion7) isNull)
+			expect((this quaternion7 - this quaternion7) isZero)
 		})
 		this add("addition", func {
 			expect(this quaternion0 + this quaternion1 == this quaternion2)

--- a/test/geometry/QuaternionTest.ooc
+++ b/test/geometry/QuaternionTest.ooc
@@ -92,14 +92,14 @@ QuaternionTest: class extends Fixture {
 			expect(normalized z, is equal to(0.8308033f) within(tolerance))
 		})
 		this add("actionOnVector", func {
-			direction := FloatPoint3D new(1.0f, 1.0f, 1.0f)
+			direction := FloatVector3D new(1.0f, 1.0f, 1.0f)
 			quaternion := Quaternion createRotation(120.0f toRadians(), direction)
 			point1 := FloatPoint3D new(5.0f, 6.0f, 7.0f)
 			point2 := FloatPoint3D new(7.0f, 5.0f, 6.0f)
 			expect((quaternion * point1) distance(point2), is equal to(0.0f))
 		})
 		this add("angle", func {
-			direction := FloatPoint3D new(1.0f, 1.0f, 1.0f)
+			direction := FloatVector3D new(1.0f, 1.0f, 1.0f)
 			quaternion1 := Quaternion createRotation(20.0f toRadians(), direction)
 			quaternion2 := Quaternion createRotation(45.0f toRadians(), direction)
 			angle := (quaternion1 angle(quaternion2)) toDegrees()
@@ -107,7 +107,7 @@ QuaternionTest: class extends Fixture {
 		})
 		this add("rotationDirectionRepresentation1", func {
 			angle := 30.0f toRadians()
-			direction := FloatPoint3D new(1.0f, 4.0f, 7.0f)
+			direction := FloatVector3D new(1.0f, 4.0f, 7.0f)
 			direction /= direction norm
 			quaternion := Quaternion createRotation(angle, direction)
 			expect(quaternion rotation, is equal to(angle) within(tolerance))


### PR DESCRIPTION
Replaced `FloatPoint3D` with `FloatVector3D` where appropriate and some other minor improvements.

* Breaks API

@niklasborwell peer review