### PR TITLE
Removed - operator and changed + to * in FloatEuclidTransform

### DIFF
--- a/source/geometry/FloatEuclidTransform.ooc
+++ b/source/geometry/FloatEuclidTransform.ooc
@@ -42,8 +42,7 @@ FloatEuclidTransform: cover {
 		"Translation: " << this translation toString() >> " Rotation: " & this rotation toString() >> " Scaling: " & this scaling toString()
 	}
 
-	operator + (other: This) -> This { This new(this translation + other translation, this rotation * other rotation, this scaling * other scaling) }
-	operator - (other: This) -> This { This new(this translation - other translation, this rotation * other rotation inverse, this scaling / other scaling) }
+	operator * (other: This) -> This { This new(this translation + other translation, this rotation * other rotation, this scaling * other scaling) }
 	operator == (other: This) -> Bool {
 		this translation == other translation &&
 		this rotation == other rotation &&


### PR DESCRIPTION
Since some of the operations carried out by the `+` operator are non-commutative it makes more sense to change this to a `*` operator for clarity. If we want to do what `-` was doing previously we should have to do `euclidTransform1 * euclidTransform2 inverse` instead of `euclidTransform1 - euclidTransform2`.
@niklasborwell @emilwestergren Thoughts?