### PR TITLE
Removed .valgrindlog from searches

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,8 @@
 		".libs": true,
 		"rock_tmp": true,
 		".vscode/": true,
-		"source/draw/stb_image": true
+		"source/draw/stb_image": true,
+		"*.valgrindlog": true
 	},
 	"files.exclude": {
 		"**/.git": true,


### PR DESCRIPTION
This filter stops VS Code from searching in `.valgrindlog` files.