### PR TITLE
Changed even more static methods in math.ooc

### DIFF
--- a/source/plot/Axis.ooc
+++ b/source/plot/Axis.ooc
@@ -12,7 +12,7 @@ Axis: class {
 	min: Float { get set }
 	max: Float { get set }
 	tick: Float { get set (length) {
-		(value, radix) := Float decomposeToCoefficientAndRadix(length, 1)
+		(value, radix) := length decomposeToCoefficientAndRadix(1)
 		this tick = radix
 		if (value != 0.0f) {
 			if (length / this tick < 1.1f)
@@ -43,7 +43,7 @@ Axis: class {
 				this fontSize = fontSize
 			this tick = this length()
 			position := FloatPoint2D new(margin x, margin y + plotAreaSize y)
-			radix := Float getRadix(this length(), this precision)
+			radix := this length() getRadix(this precision)
 			if (this orientation == Orientation Horizontal)
 				result = this getHorizontalSvg(plotAreaSize, margin, position, transform, radix)
 			else
@@ -92,7 +92,7 @@ Axis: class {
 	getRadixSvg: func (position: FloatPoint2D, radix: Float, textAnchor: String) -> String {
 		result := ""
 		if (radix >= 10 pow(this precision - 1) || radix <= 10 pow(-this precision)) {
-			scientificPower := Float getScientificPowerString(radix)
+			scientificPower := radix getScientificPowerString()
 			result = result & Shapes text(position, scientificPower, this fontSize, textAnchor)
 			scientificPower free()
 		}
@@ -132,8 +132,8 @@ Axis: class {
 	}
 	roundEndpoints: func {
 		if (this roundAxisEndpoints) {
-			this min = Float roundToValueDigits(this min, 2, false)
-			this max = Float roundToValueDigits(this max, 2, true)
+			this min = this min roundToValueDigits(2, false)
+			this max = this max roundToValueDigits(2, true)
 		}
 	}
 }

--- a/source/sdk/math.ooc
+++ b/source/sdk/math.ooc
@@ -198,11 +198,9 @@ extend Float {
 			result += ((result abs()) / divisor) ceil() * divisor
 		result mod(divisor)
 	}
-
-	maximum: static func (x, y: This) -> This { x > y ? x : y }
-	minimum: static func (x, y: This) -> This { x < y ? x : y }
-	decomposeToCoefficientAndRadix: static func (value: This, valueDigits: Int) -> (This, This) {
+	decomposeToCoefficientAndRadix: func (valueDigits: Int) -> (This, This) {
 		radix := 1.0f
+		value := this
 		if (value != 0.0f) {
 			while (value absolute >= 10.0f pow(valueDigits)) {
 				value /= 10.0f
@@ -216,24 +214,28 @@ extend Float {
 		coefficient := value
 		(coefficient, radix)
 	}
-	roundToValueDigits: static func (value: This, valueDigits: Int, up: Bool) -> This {
-		(result, radix) := This decomposeToCoefficientAndRadix(value, valueDigits)
+	roundToValueDigits: func (valueDigits: Int, up: Bool) -> This {
+		value := this
+		(result, radix) := this decomposeToCoefficientAndRadix(valueDigits)
 		if (result != 0) {
 			result = up ? result ceil() : result floor()
 			result *= radix
 		}
 		result
 	}
-	getRadix: static func (value: This, valueDigits: Int) -> This {
-		(tempValue, result) := This decomposeToCoefficientAndRadix(value, valueDigits)
+	getRadix: func (valueDigits: Int) -> This {
+		(tempValue, result) := this decomposeToCoefficientAndRadix(valueDigits)
 		result
 	}
-	getScientificPowerString: static func (value: This) -> String {
-		(coefficient, radix) := This decomposeToCoefficientAndRadix(value, 1)
+	getScientificPowerString: func -> String {
+		(coefficient, radix) := this decomposeToCoefficientAndRadix(1)
 		power := radix log10() as Int
 		result := coefficient toString() >> "E" & power toString()
 		result
 	}
+
+	maximum: static func (x, y: This) -> This { x > y ? x : y }
+	minimum: static func (x, y: This) -> This { x < y ? x : y }
 }
 
 extend LDouble {

--- a/test/math/FloatExtensionTest.ooc
+++ b/test/math/FloatExtensionTest.ooc
@@ -6,23 +6,23 @@ FloatExtensionTest: class extends Fixture {
 	init: func {
 		super("FloatExtension")
 		this add("decompose to coefficient and radix", func {
-			(coefficient, radix) := Float decomposeToCoefficientAndRadix(3333.0f, 2)
+			(coefficient, radix) := 3333.0f decomposeToCoefficientAndRadix(2)
 			expect(coefficient, is equal to(33.33f) within(this precision))
 			expect(radix, is equal to(100.0f) within(this precision))
-			(coefficient, radix) = Float decomposeToCoefficientAndRadix(0.3333f, 2)
+			(coefficient, radix) = 0.3333f decomposeToCoefficientAndRadix(2)
 			expect(coefficient, is equal to(33.33f) within(this precision))
 			expect(radix, is equal to(0.01f) within(this precision))
 		})
 		this add("round to value digits", func {
-			expect(Float roundToValueDigits(3333.0f, 2, false), is equal to(3300.0f) within(this precision))
-			expect(Float roundToValueDigits(3333.0f, 2, true), is equal to(3400.0f) within(this precision))
-			expect(Float roundToValueDigits(0.3333f, 2, false), is equal to(0.33f) within(this precision))
-			expect(Float roundToValueDigits(0.3333f, 2, true), is equal to(0.34f) within(this precision))
+			expect(3333.0f roundToValueDigits(2, false), is equal to(3300.0f) within(this precision))
+			expect(3333.0f roundToValueDigits(2, true), is equal to(3400.0f) within(this precision))
+			expect(0.3333f roundToValueDigits(2, false), is equal to(0.33f) within(this precision))
+			expect(0.3333f roundToValueDigits(2, true), is equal to(0.34f) within(this precision))
 		})
 		this add("get scientific power string", func {
-			expect(Float getScientificPowerString(3333.0f), is equal to("3.33E3"))
-			expect(Float getScientificPowerString(10000.0f), is equal to("1.00E4"))
-			expect(Float getScientificPowerString(0.0044f), is equal to("4.40E-3"))
+			expect(3333.0f getScientificPowerString(), is equal to("3.33E3"))
+			expect(10000.0f getScientificPowerString(), is equal to("1.00E4"))
+			expect(0.0044f getScientificPowerString(), is equal to("4.40E-3"))
 		})
 	}
 }


### PR DESCRIPTION
These were a lot easier than I thought. The only static methods that now remain are `minimum` and `maximum`, they will be dealt with after the weekend.

Peer review @thomasfanell ?