### PR TITLE
Fixed VS Code filter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
 		"rock_tmp": true,
 		".vscode/": true,
 		"source/draw/stb_image": true,
-		"*.valgrindlog": true
+		"**/*.valgrindlog": true
 	},
 	"files.exclude": {
 		"**/.git": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,13 +10,15 @@
 		"rock_tmp": true,
 		".vscode/": true,
 		"source/draw/stb_image": true,
-		"**/*.valgrindlog": true
+		"**/*.valgrindlog": true,
+		"**/*~": true
 	},
 	"files.exclude": {
 		"**/.git": true,
 		".libs": true,
 		"rock_tmp": true,
 		".vscode/": true,
-		"source/draw/stb_image": true
+		"source/draw/stb_image": true,
+		"**/*~": true
 	}
 }


### PR DESCRIPTION
Fixed so every `.valgrindlog` file is blocked from search, not just the ones in the project root.