### PR TITLE
Added script for test coverage analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ rock_tmp
 tests.use
 Tests
 *.valgrindlog
+/coverage/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
 		".libs": true,
 		"rock_tmp": true,
 		".vscode/": true,
+		"coverage/": true,
 		"source/draw/stb_image": true,
 		"**/*.valgrindlog": true,
 		"**/*~": true
@@ -18,6 +19,7 @@
 		".libs": true,
 		"rock_tmp": true,
 		".vscode/": true,
+		"coverage/": true,
 		"source/draw/stb_image": true,
 		"**/*~": true
 	}

--- a/codecoverage.sh
+++ b/codecoverage.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+INFO_FILE="test_coverage.info"
+ARGS=$@
+
+if [ $# -eq 0 ];
+then
+	ARGS="all"
+fi
+
+./test.sh $ARGS -x +--coverage +-O0
+lcov --quiet -t 'OOC Test coverage' -o $INFO_FILE -c --directory ./.libs/ooc/ --base-directory .
+genhtml --quiet -o coverage $INFO_FILE --num-spaces 4
+rm $INFO_FILE


### PR DESCRIPTION
Yes, bash is evil itself, but it's how we do things at the moment.

This script generates the directory `coverage` with coverage information on every file. We might want to do something similar for the other project?

(Finally) fixes #446 