### PR TITLE
Renamed createRotation in Quaternion

### DIFF
--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -193,15 +193,15 @@ Quaternion: cover {
 	createFromEulerAngles: static func (rotationX, rotationY, rotationZ: Float) -> This {
 		This createRotationZ(rotationZ) * This createRotationY(rotationY) * This createRotationX(rotationX)
 	}
-	createRotation: static func (angle: Float, direction: FloatVector3D) -> This {
-		halfAngle := angle / 2.0f
-		direction = direction isZero ? direction : direction normalized
-		This new(0.0f, (halfAngle * direction) toFloatPoint3D()) exponential
+	createFromAxisAngle: static func (axis: FloatVector3D, angle: Float) -> This {
+		axis = axis isZero ? axis : axis normalized
+		halfAngle := angle / 2.f
+		This new(halfAngle cos(), (halfAngle sin() * axis) toFloatPoint3D())
 	}
-	createRotationX: static func (angle: Float) -> This { This createRotation(angle, FloatVector3D new(1.0f, 0.0f, 0.0f)) }
-	createRotationY: static func (angle: Float) -> This { This createRotation(angle, FloatVector3D new(0.0f, 1.0f, 0.0f)) }
-	createRotationZ: static func (angle: Float) -> This { This createRotation(angle, FloatVector3D new(0.0f, 0.0f, 1.0f)) }
-	createFromEulerVector: static func (vector: FloatVector3D) -> This { vector isZero ? This identity : This createRotation(vector norm, vector normalized) }
+	createRotationX: static func (angle: Float) -> This { This createFromAxisAngle(FloatVector3D new(1.0f, 0.0f, 0.0f), angle) }
+	createRotationY: static func (angle: Float) -> This { This createFromAxisAngle(FloatVector3D new(0.0f, 1.0f, 0.0f), angle) }
+	createRotationZ: static func (angle: Float) -> This { This createFromAxisAngle(FloatVector3D new(0.0f, 0.0f, 1.0f), angle) }
+	createFromEulerVector: static func (vector: FloatVector3D) -> This { vector isZero ? This identity : This createFromAxisAngle(vector normalized, vector norm) }
 	hamiltonProduct: static func (left, right: This) -> This {
 		(a1, b1, c1, d1) := (left w, left x, left y, left z)
 		(a2, b2, c2, d2) := (right w, right x, right y, right z)

--- a/test/geometry/FloatRotation3DTest.ooc
+++ b/test/geometry/FloatRotation3DTest.ooc
@@ -76,8 +76,8 @@ FloatRotation3DTest: class extends Fixture {
 		})
 		this add("angle", func {
 			direction := FloatVector3D new(1.0f, 1.0f, 1.0f)
-			quaternionA := Quaternion createRotation(20.0f toRadians(), direction)
-			quaternionB := Quaternion createRotation(45.0f toRadians(), direction)
+			quaternionA := Quaternion createFromAxisAngle(direction, 20.0f toRadians())
+			quaternionB := Quaternion createFromAxisAngle(direction, 45.0f toRadians())
 			rotationA := FloatRotation3D new(quaternionA)
 			rotationB := FloatRotation3D new(quaternionB)
 			angle := (rotationA angle(rotationB)) toDegrees()

--- a/test/geometry/QuaternionTest.ooc
+++ b/test/geometry/QuaternionTest.ooc
@@ -93,15 +93,15 @@ QuaternionTest: class extends Fixture {
 		})
 		this add("actionOnVector", func {
 			direction := FloatVector3D new(1.0f, 1.0f, 1.0f)
-			quaternion := Quaternion createRotation(120.0f toRadians(), direction)
+			quaternion := Quaternion createFromAxisAngle(direction, 120.0f toRadians())
 			point1 := FloatPoint3D new(5.0f, 6.0f, 7.0f)
 			point2 := FloatPoint3D new(7.0f, 5.0f, 6.0f)
 			expect((quaternion * point1) distance(point2), is equal to(0.0f))
 		})
 		this add("angle", func {
 			direction := FloatVector3D new(1.0f, 1.0f, 1.0f)
-			quaternion1 := Quaternion createRotation(20.0f toRadians(), direction)
-			quaternion2 := Quaternion createRotation(45.0f toRadians(), direction)
+			quaternion1 := Quaternion createFromAxisAngle(direction, 20.0f toRadians())
+			quaternion2 := Quaternion createFromAxisAngle(direction, 45.0f toRadians())
 			angle := (quaternion1 angle(quaternion2)) toDegrees()
 			expect(angle, is equal to(25.0f) within(tolerance))
 		})


### PR DESCRIPTION
Renamed `createRotation` to `createFromAxisAngle` and removed usage of the `exponential` property as this just creates unnecessary overhead and makes the code harder to follow.