### PR TITLE
Removed as String operators from geometry covers

### DIFF
--- a/source/geometry/FloatBox2D.ooc
+++ b/source/geometry/FloatBox2D.ooc
@@ -154,7 +154,6 @@ FloatBox2D: cover {
 	operator * (other: FloatVector2D) -> This { This new(this leftTop * other, this size * other) }
 	operator / (other: FloatVector2D) -> This { This new(this leftTop / other, this size / other) }
 	operator - (other: FloatVector2D) -> This { This new(this leftTop, this size - other) }
-	operator as -> String { this toString() }
 
 	parse: static func (input: Text) -> This {
 		parts := input split(',')

--- a/source/geometry/FloatPoint2D.ooc
+++ b/source/geometry/FloatPoint2D.ooc
@@ -67,7 +67,6 @@ FloatPoint2D: cover {
 	operator / (other: FloatVector2D) -> This { This new(this x / other x, this y / other y) }
 	operator * (other: Float) -> This { This new(this x * other, this y * other) }
 	operator / (other: Float) -> This { This new(this x / other, this y / other) }
-	operator as -> String { this toString() }
 
 	basisX: static This { get { This new(1, 0) } }
 	basisY: static This { get { This new(0, 1) } }

--- a/source/geometry/FloatPoint3D.ooc
+++ b/source/geometry/FloatPoint3D.ooc
@@ -67,7 +67,6 @@ FloatPoint3D: cover {
 	operator != (other: This) -> Bool { this x != other x || this y != other y || this z != other z }
 	operator * (other: Float) -> This { This new(this x * other, this y * other, this z * other) }
 	operator / (other: Float) -> This { This new(this x / other, this y / other, this z / other) }
-	operator as -> String { this toString() }
 
 	spherical: static func (radius, azimuth, elevation: Float) -> This {
 		This new(radius * (azimuth cos()) * (elevation sin()), radius * (azimuth sin()) * (elevation sin()), radius * (elevation cos()))

--- a/source/geometry/FloatShell2D.ooc
+++ b/source/geometry/FloatShell2D.ooc
@@ -53,7 +53,6 @@ FloatShell2D: cover {
 	operator == (other: This) -> Bool { this left == other left && this right == other right && this top == other top && this bottom == other bottom }
 	operator != (other: This) -> Bool { !(this == other) }
 	operator / (other: Float) -> This { This new(this left / other, this right / other, this top / other, this bottom / other) }
-	operator as -> String { this toString() }
 
 	parse: static func (input: Text) -> This {
 		parts := input split(',')

--- a/source/geometry/FloatTransform2D.ooc
+++ b/source/geometry/FloatTransform2D.ooc
@@ -173,9 +173,6 @@ FloatTransform2D: cover {
 		}
 		result
 	}
-	operator as -> String {
-		this toString()
-	}
 
 	identity: static This { get { This new(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f) } }
 	create: static func (translation: FloatVector2D, scale, rotation: Float) -> This {

--- a/source/geometry/FloatTransform3D.ooc
+++ b/source/geometry/FloatTransform3D.ooc
@@ -227,9 +227,6 @@ FloatTransform3D: cover {
 			this c * other x + this g * other y + this k * other z + this o
 		)
 	}
-	operator as -> String {
-		this toString()
-	}
 
 	kean_math_floatTransform3D_getTranslation: unmangled func -> FloatVector3D { this translation }
 	kean_math_floatTransform3D_getScaling: unmangled func -> FloatVector3D { FloatVector3D new(this scalingX, this scalingY, this scalingZ) }

--- a/source/geometry/FloatVector2D.ooc
+++ b/source/geometry/FloatVector2D.ooc
@@ -71,7 +71,6 @@ FloatVector2D: cover {
 	operator / (other: Float) -> This { This new(this x / other, this y / other) }
 	operator * (other: Int) -> This { This new(this x * other, this y * other) }
 	operator / (other: Int) -> This { This new(this x / other, this y / other) }
-	operator as -> String { this toString() }
 
 	basisX: static This { get { This new(1, 0) } }
 	basisY: static This { get { This new(0, 1) } }

--- a/source/geometry/FloatVector3D.ooc
+++ b/source/geometry/FloatVector3D.ooc
@@ -74,7 +74,6 @@ FloatVector3D: cover {
 	operator / (other: Float) -> This { This new(this x / other, this y / other, this z / other) }
 	operator * (other: Int) -> This { This new(this x * other, this y * other, this z * other) }
 	operator / (other: Int) -> This { This new(this x / other, this y / other, this z / other) }
-	operator as -> String { this toString() }
 
 	basisX: static This { get { This new(1, 0, 0) } }
 	basisY: static This { get { This new(0, 1, 0) } }

--- a/source/geometry/IntBox2D.ooc
+++ b/source/geometry/IntBox2D.ooc
@@ -121,7 +121,6 @@ IntBox2D: cover {
 	operator - (other: IntPoint2D) -> This { This new(this leftTop - other, this size) }
 	operator + (other: IntVector2D) -> This { This new(this leftTop, this size + other) }
 	operator - (other: IntVector2D) -> This { This new(this leftTop, this size - other) }
-	operator as -> String { this toString() }
 
 	parse: static func (input: Text) -> This {
 		parts := input split(',')

--- a/source/geometry/IntPoint2D.ooc
+++ b/source/geometry/IntPoint2D.ooc
@@ -50,7 +50,6 @@ IntPoint2D: cover {
 	operator / (other: IntVector2D) -> This { This new(this x / other x, this y / other y) }
 	operator * (other: Int) -> This { This new(this x * other, this y * other) }
 	operator / (other: Int) -> This { This new(this x / other, this y / other) }
-	operator as -> String { this toString() }
 
 	parse: static func (input: Text) -> This {
 		parts := input split(',')

--- a/source/geometry/IntPoint3D.ooc
+++ b/source/geometry/IntPoint3D.ooc
@@ -49,7 +49,6 @@ IntPoint3D: cover {
 	operator / (other: IntVector3D) -> This { This new(this x / other x, this y / other y, this z / other z) }
 	operator * (other: Int) -> This { This new(this x * other, this y * other, this z * other) }
 	operator / (other: Int) -> This { This new(this x / other, this y / other, this z / other) }
-	operator as -> String { this toString() }
 
 	parse: static func (input: Text) -> This {
 		parts := input split(',')

--- a/source/geometry/IntShell2D.ooc
+++ b/source/geometry/IntShell2D.ooc
@@ -52,7 +52,6 @@ IntShell2D: cover {
 	operator == (other: This) -> Bool { this left == other left && this right == other right && this top == other top && this bottom == other bottom }
 	operator != (other: This) -> Bool { !(this == other) }
 	operator / (other: Int) -> This { This new(this left / other, this right / other, this top / other, this bottom / other) }
-	operator as -> String { this toString() }
 
 	parse: static func (input: Text) -> This {
 		parts := input split(',')

--- a/source/geometry/IntTransform2D.ooc
+++ b/source/geometry/IntTransform2D.ooc
@@ -139,9 +139,6 @@ IntTransform2D: cover {
 		divisor := this c * other x + this f * other y + this i
 		IntPoint2D new((this a * other x + this d * other y + this g) / divisor, (this b * other x + this e * other y + this h) / divisor)
 	}
-	operator as -> String {
-		this toString()
-	}
 
 	identity: static This { get { This new(1, 0, 0, 1, 0, 0) } }
 	toFloatTransform2D: func -> FloatTransform2D { FloatTransform2D new(this a, this b, this c, this d, this e, this f, this g, this h, this i) }

--- a/source/geometry/IntVector2D.ooc
+++ b/source/geometry/IntVector2D.ooc
@@ -60,7 +60,6 @@ IntVector2D: cover {
 	operator / (other: Float) -> This { This new(this x / other, this y / other) }
 	operator * (other: Int) -> This { This new(this x * other, this y * other) }
 	operator / (other: Int) -> This { This new(this x / other, this y / other) }
-	operator as -> String { this toString() }
 
 	basisX: static This { get { This new(1, 0) } }
 	basisY: static This { get { This new(0, 1) } }

--- a/source/geometry/IntVector3D.ooc
+++ b/source/geometry/IntVector3D.ooc
@@ -51,7 +51,6 @@ IntVector3D: cover {
 	operator / (other: Float) -> This { This new(this x / other, this y / other, this z / other) }
 	operator * (other: Int) -> This { This new(this x * other, this y * other, this z * other) }
 	operator / (other: Int) -> This { This new(this x / other, this y / other, this z / other) }
-	operator as -> String { this toString() }
 
 	basisX: static This { get { This new(1, 0, 0) } }
 	basisY: static This { get { This new(0, 1, 0) } }

--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -186,7 +186,6 @@ Quaternion: cover {
 	operator / (value: Float) -> This { This new(this w / value, this x / value, this y / value, this z / value) }
 	operator * (value: Float) -> This { This new(this w * value, this x * value, this y * value, this z * value) }
 	operator * (value: FloatPoint3D) -> FloatPoint3D { This hamiltonProduct(This hamiltonProduct(this, This new(0.0f, value)), this inverse) imaginary }
-	operator as -> String { this toString() }
 
 	precision: static Float = 1.0e-6f
 	identity: static This { get { This new(1.0f, 0.0f, 0.0f, 0.0f) } }


### PR DESCRIPTION
As discussed yesterday, @thomasfanell - we don't do this anywhere else, the SDK hardly even does it, and we don't use it.

Peer review?