### PR TITLE
Moved codecoverage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ tests.use
 Tests
 *.valgrindlog
 /coverage/
+*.info

--- a/tools/codecoverage.sh
+++ b/tools/codecoverage.sh
@@ -9,6 +9,10 @@ fi
 
 ./test.sh $ARGS -x +--coverage +-O0
 lcov --quiet -t 'OOC Test coverage' -o $INFO_FILE -c --directory ./.libs/ooc/ --base-directory .
+lcov --quiet --remove test_coverage.info '/rock_tmp/*' -o test_coverage.info
+lcov --quiet --remove test_coverage.info '/test/*' -o test_coverage.info
+
+rm -r coverage/
 genhtml --quiet -o coverage $INFO_FILE --num-spaces 4
 rm $INFO_FILE
 


### PR DESCRIPTION
Fixes #1178 
Removes generated c sources and test files from lcov output. Also removes `coverage/` folder before generating a new one.