### PR TITLE
Modified static uses of non-static methods

### DIFF
--- a/source/geometry/FloatBox2D.ooc
+++ b/source/geometry/FloatBox2D.ooc
@@ -84,10 +84,10 @@ FloatBox2D: cover {
 		This createAround(this center, value * this size)
 	}
 	enlargeTo: func (size: FloatVector2D) -> This {
-		This createAround(this center, FloatVector2D maximum(this size, size))
+		This createAround(this center, this size maximum(size))
 	}
 	shrinkTo: func (size: FloatVector2D) -> This {
-		This createAround(this center, FloatVector2D minimum(this size, size))
+		This createAround(this center, this size minimum(size))
 	}
 	intersection: func (other: This) -> This {
 		left := Float maximum(this left, other left)
@@ -119,7 +119,7 @@ FloatBox2D: cover {
 	maximumDistance: func (points: VectorList<FloatPoint2D>) -> FloatVector2D {
 		result := FloatVector2D new()
 		for (index in 0 .. points count)
-			result = FloatVector2D maximum(this distance(points[index]), result)
+			result = result maximum(this distance(points[index]))
 		result
 	}
 	round: func -> This { This new(this leftTop round(), this size round()) }

--- a/source/geometry/IntBox2D.ooc
+++ b/source/geometry/IntBox2D.ooc
@@ -75,10 +75,10 @@ IntBox2D: cover {
 		This createAround(this center, value * this size)
 	}
 	enlargeTo: func (size: IntVector2D) -> This {
-		This createAround(this center, IntVector2D maximum(this size, size))
+		This createAround(this center, this size maximum(size))
 	}
 	shrinkTo: func (size: IntVector2D) -> This {
-		This createAround(this center, IntVector2D minimum(this size, size))
+		This createAround(this center, this size minimum(size))
 	}
 	intersection: func (other: This) -> This {
 		left := Int maximum(this left, other left)


### PR DESCRIPTION
In ooc, it appears you can use non-static methods as static methods, which is either a bug or a feature. Anyhow, this is more in line with other `maximum`/`minimum` calls of our geometry covers and with #1172 

@sebastianbaginski ?