### PR TITLE
We don't have to be smarter (in Text) right now

### DIFF
--- a/source/sdk/Text.ooc
+++ b/source/sdk/Text.ooc
@@ -116,7 +116,7 @@ Text: cover {
 	slice: func (start: Int, distance := INT_MAX) -> This {
 		result := This new(this _buffer slice(start, distance == INT_MAX ? this count - start : distance))
 		if (this _buffer owner == Owner Receiver)
-			result = result copy() // TODO: Could we be smarter here?
+			result = result copy()
 		this free(Owner Receiver)
 		result
 	}


### PR DESCRIPTION
Removing this `TODO` and in the process closing #747 

We don't seem to need this now, and if we ever want to make this better, by introducing a reference counter (see the issue), we will create an issue *then*, not have one that just lingers.

Does that seem OK @sebastianbaginski ?