### PR TITLE
Removed inline and const keywords

### DIFF
--- a/source/sdk/Format.ooc
+++ b/source/sdk/Format.ooc
@@ -51,7 +51,7 @@ FSInfoStruct: cover {
 __digits: String = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 __digits_small: String = "0123456789abcdefghijklmnopqrstuvwxyz"
 
-argNext: inline func<T> (va: VarArgsIterator*, T: Class) -> T {
+argNext: func<T> (va: VarArgsIterator*, T: Class) -> T {
 	if (!va@ hasNext?()) InvalidFormatException new(null) throw()
 	return va@ next(T)
 }
@@ -341,7 +341,7 @@ parseArgOne: func <T> (res: CharBuffer, info: FSInfoStruct*, va: T, p: Char*) {
 	}
 }
 
-getEntityInfo: inline func (info: FSInfoStruct@, va: VarArgsIterator*, start: Char*, end: Pointer) {
+getEntityInfo: func (info: FSInfoStruct@, va: VarArgsIterator*, start: Char*, end: Pointer) {
 	/* save original pointer */
 	p := start
 
@@ -403,7 +403,7 @@ getEntityInfo: inline func (info: FSInfoStruct@, va: VarArgsIterator*, start: Ch
 	info bytesProcessed = p as SizeT - start as SizeT
 }
 
-getEntityInfoOne: inline func <T> (info: FSInfoStruct@, va: T*, start: Char*, end: Pointer) {
+getEntityInfoOne: func <T> (info: FSInfoStruct@, va: T*, start: Char*, end: Pointer) {
 	/* save original pointer */
 	p := start
 	/* Find any flags. */

--- a/source/sdk/IO.ooc
+++ b/source/sdk/IO.ooc
@@ -88,11 +88,11 @@ FStream: cover from FILE* {
 	 * suffix "b" = binary mode
 	 * suffix "t" = text mode (warning: tell/seek are unreliable in text mode under mingw32)
 	 */
-	open: static func (filename, mode: const String) -> This {
+	open: static func (filename, mode: String) -> This {
 		fopen(filename, mode)
 	}
 
-	open: static func ~withFlags (filename, mode: const String, flags: Int) -> This {
+	open: static func ~withFlags (filename, mode: String, flags: Int) -> This {
 		fd := open(filename, flags)
 		fdopen(fd, mode)
 	}

--- a/source/sdk/VarArgs.ooc
+++ b/source/sdk/VarArgs.ooc
@@ -1,7 +1,7 @@
 // that thunk is needed to correctly infer the 'T'. It shows at the
 // same time the limitations of ooc generics and still how incredibly
 // powerful they are.
-__va_call: inline func <T> (f: Func <T> (T), T: Class, arg: T) {
+__va_call: func <T> (f: Func <T> (T), T: Class, arg: T) {
 	f(arg)
 }
 
@@ -12,7 +12,7 @@ __sizeof: extern (sizeof) func (Class) -> SizeT
 
 // used to align values on the pointer-size boundary, both for performance
 // and to match the layout of structs
-__pointer_align: inline func (s: SizeT) -> SizeT {
+__pointer_align: func (s: SizeT) -> SizeT {
 	// 'Pointer size' isn't a constant expression, but sizeof(Pointer) is.
 	ps := static __sizeof(Pointer)
 	diff := s % ps

--- a/source/sdk/io/File.ooc
+++ b/source/sdk/io/File.ooc
@@ -266,7 +266,7 @@ File: abstract class {
 
 	separator: static Char
 	pathDelimiter: static Char
-	MAX_PATH_LENGTH := static const 16383
+	MAX_PATH_LENGTH := static 16383
 
 	new: static func (.path) -> This {
 		version (unix || apple) {
@@ -304,6 +304,6 @@ File: abstract class {
 	}
 }
 
-_isDirHardlink: inline func (dir: CString) -> Bool {
+_isDirHardlink: func (dir: CString) -> Bool {
 	(dir[0] == '.') && (dir[1] == '\0' || ( dir[1] == '.' && dir[2] == '\0'))
 }

--- a/source/sdk/lang/types.ooc
+++ b/source/sdk/lang/types.ooc
@@ -42,7 +42,7 @@ Class: abstract class {
 	name: String
 
 	// Pointer to instance of super-class
-	super: const This
+	super: This
 
 	// Create a new instance of the object of type defined by this class
 	alloc: final func ~_class -> Object {

--- a/source/sdk/stdlib.ooc
+++ b/source/sdk/stdlib.ooc
@@ -1,7 +1,7 @@
 include stdlib
 
 exit: extern func (Int)
-EXIT_SUCCESS: extern const Int
-EXIT_FAILURE: extern const Int
+EXIT_SUCCESS: extern Int
+EXIT_FAILURE: extern Int
 
 atexit: extern func (Pointer)

--- a/source/sdk/structs/ArrayList.ooc
+++ b/source/sdk/structs/ArrayList.ooc
@@ -68,7 +68,7 @@ ArrayList: class <T> extends List<T> {
 		_size = 0
 	}
 
-	get: override inline func (index: SSizeT) -> T {
+	get: override func (index: SSizeT) -> T {
 		if (index < 0) index = _size + index
 		if (index < 0 || index >= _size) OutOfBoundsException new(This, index, _size) throw()
 		checkIndex(index)
@@ -140,9 +140,9 @@ ArrayList: class <T> extends List<T> {
 		data[index] = element
 	}
 
-	getSize: override inline func -> SizeT { _size }
+	getSize: override func -> SizeT { _size }
 
-	ensureCapacity: inline func (newSize: SizeT) {
+	ensureCapacity: func (newSize: SizeT) {
 		if (newSize > capacity) {
 			capacity = newSize * (newSize > 50000 ? 2 : 4)
 			tmpData := gc_realloc(data, capacity * T size)
@@ -155,7 +155,7 @@ ArrayList: class <T> extends List<T> {
 	}
 
 	/** private */
-	checkIndex: inline func (index: SSizeT) {
+	checkIndex: func (index: SSizeT) {
 		if (index >= _size) {
 			OutOfBoundsException new(This, index, _size) throw()
 		}

--- a/source/sdk/structs/HashMap.ooc
+++ b/source/sdk/structs/HashMap.ooc
@@ -44,8 +44,8 @@ murmurHash: func <K> (keyTagazok: K) -> SizeT {
 	seed: SizeT = 1
 
 	len := K size
-	m = 0x5bd1e995 : const SizeT
-	r = 24 : const SSizeT
+	m = 0x5bd1e995: SizeT
+	r = 24: SSizeT
 	l := len
 
 	h : SizeT = seed ^ len
@@ -259,7 +259,7 @@ HashMap: class <K, V> extends BackIterable<V> {
 		}
 		true
 	}
-	add: inline func (key: K, value: V) -> Bool {
+	add: func (key: K, value: V) -> Bool {
 		put(key, value)
 	}
 	get: func (key: K) -> V {

--- a/source/sdk/structs/List.ooc
+++ b/source/sdk/structs/List.ooc
@@ -245,7 +245,7 @@ List: abstract class <T> extends BackIterable<T> {
 		copy
 	}
 
-	filterEach: inline func (f: Func(T) -> Bool, g: Func(T)) {
+	filterEach: func (f: Func(T) -> Bool, g: Func(T)) {
 		filter(f) each(g)
 	}
 


### PR DESCRIPTION
Rock just rips out the `const` keyword anyway, and `inline` won't really help `gcc` with the code that's generated anyway.

Fixes #1197 

@sebastianbaginski ?