### PR TITLE
Added -Wall to test script

### DIFF
--- a/source/draw/gpu/GpuSurface.ooc
+++ b/source/draw/gpu/GpuSurface.ooc
@@ -89,7 +89,7 @@ GpuSurface: abstract class extends Canvas {
 			temporary free()
 	}
 	draw: virtual func ~mesh (image: GpuImage, mesh: GpuMesh) { Debug raise("draw~mesh unimplemented!") }
-	readPixels: virtual func -> ByteBuffer { raise("readPixels unimplemented!") }
+	readPixels: virtual func -> ByteBuffer { raise("readPixels unimplemented!"); null }
 	_createTextureTransform: static func (imageSize: IntVector2D, box: IntBox2D) -> FloatTransform3D {
 		scaling := FloatTransform3D createScaling(box size x as Float / imageSize x, box size y as Float / imageSize y, 1.0f)
 		translation := FloatTransform3D createTranslation(box leftTop x as Float / imageSize x, box leftTop y as Float / imageSize y, 0.0f)

--- a/source/sdk/Exception.ooc
+++ b/source/sdk/Exception.ooc
@@ -76,7 +76,7 @@ ExceptionContext: class {
 exceptionContext := ExceptionContext new()
 
 _pushStackFrame: func -> StackFrame { exceptionContext pushStackFrame() }
-_popStackFrame: func -> StackFrame { exceptionContext popStackFrame() }
+_popStackFrame: func { exceptionContext popStackFrame() }
 _getException: func -> Exception { exceptionContext exception }
 
 version(windows) {

--- a/test.sh
+++ b/test.sh
@@ -40,7 +40,7 @@ do
 done
 echo "Main: ./test/Tests.ooc" >> "$TESTS_USE_FILE"
 rm -f .libs/tests-linux64.*
-rock -q --gc=off $ARGS $FLAGS $FEATURES $TESTS_USE_FILE && ./Tests
+rock -q --gc=off +-Wall $ARGS $FLAGS $FEATURES $TESTS_USE_FILE && ./Tests
 if [[ !( $? == 0 ) ]]
 then
 	exit 1

--- a/test/io/CsvReaderTest.ooc
+++ b/test/io/CsvReaderTest.ooc
@@ -42,15 +42,6 @@ CsvReaderTest: class extends Fixture {
 			filename free()
 			reader free()
 		})
-		this add("map", func {
-			filename := Text new(c"test/io/input/3x3.csv", 21)
-			reader := CsvReader open(filename) map(VectorList<Float>, |row| This toFloats)
-			filename free()
-			reader free()
-		})
-	}
-	toFloats: static func (row: VectorList<Text>) -> VectorList<Float> {
-		row map(|value| value toFloat())
 	}
 }
 


### PR DESCRIPTION
Also fixes some of the points of #1212 

`PRInt` already runs with this flag (as of today). Once we've fixed these warnings, `PRInt` will switch to `-Werror` and not allow any new warnings.

Since this is a library, it would have been nice with `-Wall -Wextra`, but that just fills the screen with rock-related nonsense we will never fix.

Peer review @fredrikbryntesson ?