### PR TITLE
Added code coverage extension functionality to VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
 		"rock_tmp": true,
 		".vscode/": true,
 		"coverage/": true,
+		"*.info": true,
 		"source/draw/stb_image": true,
 		"**/*.valgrindlog": true,
 		"**/*~": true
@@ -20,6 +21,7 @@
 		"rock_tmp": true,
 		".vscode/": true,
 		"coverage/": true,
+		"*.info": true,
 		"source/draw/stb_image": true,
 		"**/*~": true
 	}

--- a/coverageconfig.json
+++ b/coverageconfig.json
@@ -1,0 +1,4 @@
+{
+    "coverage": ["test_coverage.info"],
+    "sourcemapped": [".libs/"]
+}

--- a/tools/codecoverage.sh
+++ b/tools/codecoverage.sh
@@ -14,7 +14,6 @@ lcov --quiet --remove test_coverage.info '/test/*' -o test_coverage.info
 
 rm -r coverage/
 genhtml --quiet -o coverage $INFO_FILE --num-spaces 4
-rm $INFO_FILE
 
 if which xdg-open > /dev/null
 then


### PR DESCRIPTION
Unfortunately, the json file must be located in the root. :/
I don't know how you want to integrate this with magic etc. later, but this works for now. @thomasfanell - peer review?