### PR TITLE
Removed ooc-draw-test.use

### DIFF
--- a/test/draw/ooc-draw-test.use
+++ b/test/draw/ooc-draw-test.use
@@ -1,8 +1,0 @@
-Name: ooc Draw Test
-Description: Draw functionality library test.
-SourcePath: .
-Requires: ooc-unit
-Requires: ooc-math
-Requires: ooc-test
-Requires: ooc-draw
-Imports: ImageFileTest


### PR DESCRIPTION
@emilwestergren Do you perhaps know anything about why this file exists? Otherwise, I'm throwing it away.