### PR TITLE
Include limits header when targeting OS X

### DIFF
--- a/source/sdk/Numbers.ooc
+++ b/source/sdk/Numbers.ooc
@@ -1,5 +1,5 @@
 include stdlib, stdint, stddef, float, ctype, sys/types
-version(windows) {
+version(windows || apple) {
 	include limits
 }
 


### PR DESCRIPTION
* The header `limits` was not included when targeting OS X, causing the build to fail.

@marcusnaslund peer review?