### PR TITLE
Added final override to silence rock warning

### DIFF
--- a/source/io/CsvReader.ooc
+++ b/source/io/CsvReader.ooc
@@ -15,7 +15,7 @@ CsvReader: class extends Iterator<VectorList<Text>> {
 	remove: override func -> Bool { false }
 	iterator: func -> This { this }
 	hasNext?: override func -> Bool { this _fileReader hasNext?() }
-	next: func -> VectorList<Text> {
+	next: final override func -> VectorList<Text> {
 		result: VectorList<Text>
 		if (this hasNext?()) {
 			readCharacter: Char


### PR DESCRIPTION
Adding `final` when overriding an abstract function seems to eliminate the warning, and it seems to work as expected.