### PR TITLE
fixed cppcheck warnings

### DIFF
--- a/source/base/DateTime.ooc
+++ b/source/base/DateTime.ooc
@@ -31,7 +31,7 @@ DateTimeData: cover {
 
 extend Time {
 	currentDateTime: static func -> DateTime {
-		result := DateTime new(0)
+		result: DateTime
 		version(windows) {
 				st: SystemTime
 				GetLocalTime(st&)

--- a/source/sdk/os/Env.ooc
+++ b/source/sdk/os/Env.ooc
@@ -29,7 +29,7 @@ Env: class {
 		set(key, value, true)
 	}
 	unset: static func (key: String) -> Int {
-		result := -1
+		result: Int
 		version(windows) {
 			// under mingw, this unsets the key
 			result = putenv((key + "=") toCString())


### PR DESCRIPTION
Warnings when analyzing generated C code with cppcheck. Variables reassigned before old value was used.
@marcusnaslund 